### PR TITLE
Fix hardcoded mamba path in environment runner and manager

### DIFF
--- a/chorus/core/environment/manager.py
+++ b/chorus/core/environment/manager.py
@@ -163,7 +163,7 @@ class EnvironmentManager:
         from chorus import PACKAGE_DIR
         env_name = self.get_environment_name(oracle)
 
-        running_command = shlex.split(f"mamba run -n {env_name} python -m pip install -e . --no-deps --no-build-isolation")
+        running_command = shlex.split(f"{self.conda_exe} run -n {env_name} python -m pip install -e . --no-deps --no-build-isolation")
         result = subprocess.run(
                 running_command,
                 capture_output=True,

--- a/chorus/core/environment/runner.py
+++ b/chorus/core/environment/runner.py
@@ -103,7 +103,8 @@ except Exception as e:
         try:
             # Run the script file instead of passing code as argument
             env_name = self.env_manager.get_environment_name(oracle)
-            running_command = shlex.split(f"mamba run -n {env_name} python {code_path}")
+            conda_exe = self.env_manager.conda_exe
+            running_command = shlex.split(f"{conda_exe} run -n {env_name} python {code_path}")
 
             env = os.environ.copy()
             


### PR DESCRIPTION
## Summary
- Fix `EnvironmentRunner.run_code_in_environment()` and `EnvironmentManager.install_chorus_primitive()` which hardcoded `mamba` in subprocess calls
- When `mamba` is not on `PATH` (e.g. only discoverable via `MAMBA_EXE` env var), model loading fails with `FileNotFoundError: [Errno 2] No such file or directory: 'mamba'`
- Now uses the resolved `conda_exe` path from `EnvironmentManager`, which already handles discovery via `MAMBA_EXE`, `CONDA_EXE`, and common installation paths

## Test plan
- [x] Verified fix on a system where `mamba` is only available via `MAMBA_EXE` env var
- [x] Successfully loaded and ran ChromBPNet ATAC predictions for K562, HepG2, and GM12878 after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)