### PR TITLE
Add multi-architecture support for ARM macOS

### DIFF
--- a/chorus/core/environment/manager.py
+++ b/chorus/core/environment/manager.py
@@ -4,12 +4,14 @@ import os
 import json
 import subprocess
 import logging
+import tempfile
 from pathlib import Path
 from typing import List, Dict, Optional, Tuple
 import yaml
 import sys
 
 from ..globals import CHORUS_ENVIRONMENTS_DIR
+from ..platform import detect_platform, adapt_environment_config, PlatformInfo
 
 logger = logging.getLogger(__name__)
 
@@ -20,7 +22,7 @@ class EnvironmentManager:
     def __init__(self, base_path: Optional[Path] = None, conda_exe: Optional[str] = None):
         """
         Initialize the environment manager.
-        
+
         Args:
             base_path: Base path for environments directory
             conda_exe: Path to conda executable
@@ -28,15 +30,18 @@ class EnvironmentManager:
         if base_path is None:
             # Default to package root/environments
             base_path = CHORUS_ENVIRONMENTS_DIR
-        
+
         self.base_path = Path(base_path)
         self.base_path.mkdir(exist_ok=True)
-        
+
         # Try to find conda executable
         self.conda_exe = conda_exe or self._find_conda_executable()
         if not self.conda_exe:
             raise RuntimeError("Could not find conda executable. Please install conda or mamba.")
-        
+
+        # Detect platform once at init
+        self.platform_info = detect_platform()
+
         # Cache for environment status
         self._env_cache = {}
         
@@ -177,39 +182,72 @@ class EnvironmentManager:
     def create_environment(self, oracle: str, force: bool = False) -> bool:
         """
         Create a mamba environment for the given oracle.
-        
+
+        Detects the current platform architecture and adapts the environment
+        YAML if needed (e.g. different TensorFlow versions for ARM macOS,
+        removing CUDA packages on non-GPU systems).
+
         Args:
             oracle: Name of the oracle
             force: If True, recreate environment even if it exists
-            
+
         Returns:
             True if successful, False otherwise
         """
         env_name = self.get_environment_name(oracle)
         env_file = self.get_environment_file(oracle)
-        
+
         if not env_file.exists():
             logger.error(f"Environment file not found: {env_file}")
             return False
-        
+
         # Check if environment already exists
         if self.environment_exists(oracle) and not force:
             logger.info(f"Environment {env_name} already exists")
             return True
-        
+
         # Remove existing environment if force is True
         if force and self.environment_exists(oracle):
             logger.info(f"Removing existing environment {env_name}")
             self.remove_environment(oracle)
-        
+
+        # Load and adapt the YAML for the current platform
+        with open(env_file, 'r') as f:
+            env_config = yaml.safe_load(f)
+
+        adapted_config, post_install_steps, notes = adapt_environment_config(
+            env_config, oracle, self.platform_info
+        )
+
+        # Log any platform adaptations
+        if notes:
+            logger.info(
+                f"Platform adaptation ({self.platform_info.key}) for {oracle}:"
+            )
+            for note in notes:
+                logger.info(f"  - {note}")
+
+        # Determine which file to pass to conda
+        if adapted_config is not env_config:
+            # Write adapted config to a temp file
+            tmp_file = tempfile.NamedTemporaryFile(
+                mode='w', suffix='.yml', prefix=f'chorus-{oracle}-',
+                delete=False
+            )
+            yaml.dump(adapted_config, tmp_file, default_flow_style=False)
+            tmp_file.close()
+            effective_env_file = tmp_file.name
+            logger.info(f"Using adapted environment file: {effective_env_file}")
+        else:
+            effective_env_file = str(env_file)
+
         # Create environment
         logger.info(f"Creating environment {env_name} from {env_file}")
         try:
-            cmd = [self.conda_exe, 'env', 'create', '-f', str(env_file), '-y']
-            
-            # Use mamba if available for faster solving
-            if 'mamba' in self.conda_exe:
-                cmd = [self.conda_exe, 'env', 'create', '-f', str(env_file), '-y']
+            cmd = [
+                self.conda_exe, 'env', 'create',
+                '-f', effective_env_file, '-y'
+            ]
 
             process = subprocess.Popen(
                 cmd,
@@ -220,23 +258,81 @@ class EnvironmentManager:
 
             # Stream output live
             for line in process.stdout:
-                print(line, end="") 
+                print(line, end="")
 
             process.wait()
 
-            self.install_chorus_primitive(oracle)
-
-            if process.returncode == 0:
-                logger.info(f"Successfully created environment {env_name}")
-                self._env_cache[env_name] = True
-                return True
-            else:
+            if process.returncode != 0:
                 logger.error(f"Failed to create environment: {process.stderr}")
                 return False
-                
+
+            # Run post-install steps (e.g. pip install --no-deps)
+            if post_install_steps:
+                if not self._run_post_install(oracle, post_install_steps):
+                    logger.error(
+                        f"Post-install steps failed for {oracle}. "
+                        f"Environment was created but may be incomplete."
+                    )
+                    return False
+
+            self.install_chorus_primitive(oracle)
+
+            logger.info(f"Successfully created environment {env_name}")
+            self._env_cache[env_name] = True
+            return True
+
         except subprocess.CalledProcessError as e:
             logger.error(f"Error creating environment: {e}")
             return False
+        finally:
+            # Clean up temp file
+            if adapted_config is not env_config:
+                try:
+                    os.unlink(effective_env_file)
+                except OSError:
+                    pass
+
+    def _run_post_install(self, oracle: str, steps) -> bool:
+        """Run post-install pip commands in the oracle's environment.
+
+        Args:
+            oracle: Oracle name.
+            steps: List of PostInstallStep objects.
+
+        Returns:
+            True if all steps succeeded.
+        """
+        env_name = self.get_environment_name(oracle)
+
+        for step in steps:
+            if step.description:
+                logger.info(f"Post-install: {step.description}")
+
+            cmd = [
+                self.conda_exe, 'run', '-n', env_name,
+                'python', '-m', 'pip', 'install',
+            ] + step.flags + step.packages
+
+            logger.info(f"Running: {' '.join(cmd)}")
+
+            process = subprocess.Popen(
+                cmd,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+            )
+            for line in process.stdout:
+                print(line, end="")
+            process.wait()
+
+            if process.returncode != 0:
+                logger.error(
+                    f"Post-install step failed: "
+                    f"pip install {' '.join(step.flags)} {' '.join(step.packages)}"
+                )
+                return False
+
+        return True
     
     def remove_environment(self, oracle: str) -> bool:
         """Remove a conda environment for the given oracle."""

--- a/chorus/core/platform.py
+++ b/chorus/core/platform.py
@@ -102,7 +102,8 @@ def _pkg_name(spec: str) -> str:
         'numpy>=1.21.0' -> 'numpy'
         'protobuf==3.20' -> 'protobuf'
     """
-    for sep in ('==', '>=', '<=', '!=', '<', '>', '~='):
+    # Check multi-char separators first, then single-char
+    for sep in ('==', '>=', '<=', '!=', '~=', '<', '>', '='):
         if sep in spec:
             return spec.split(sep)[0].strip()
     return spec.strip()
@@ -156,29 +157,37 @@ PLATFORM_ADAPTATIONS: Dict[str, Dict[str, EnvironmentAdaptation]] = {
             pip_replace={
                 "tensorflow": "tensorflow>=2.15.0,<2.17.0",
             },
+            pip_add=[
+                "setuptools<81",  # tensorflow_hub needs pkg_resources
+            ],
             notes=[
                 "TensorFlow <2.13 is not available for Apple Silicon; "
                 "broadening range to >=2.15",
+                "Pinned setuptools<81 (tensorflow_hub requires pkg_resources)",
             ],
         ),
     },
     "borzoi": {
         "macos_arm64": EnvironmentAdaptation(
-            conda_remove=["cudatoolkit"],
-            pip_remove=["nvidia::cuda-nvcc"],
-            channels_remove=["nvidia"],
+            conda_remove=["cudatoolkit", "nvidia::cuda-nvcc"],
+            channels_remove=["pytorch", "nvidia"],
             notes=[
                 "CUDA packages removed (not available on macOS); "
                 "PyTorch will use CPU/MPS backend",
+                "Removed pytorch channel (available on conda-forge for ARM Mac)",
             ],
         ),
     },
     "sei": {
         "macos_arm64": EnvironmentAdaptation(
-            conda_remove=["cudatoolkit"],
+            conda_remove=["cudatoolkit", "pytorch", "torchvision"],
+            conda_add=["pytorch>=1.13.0", "torchvision>=0.14.0"],
+            channels_remove=["pytorch"],
             notes=[
                 "CUDA toolkit removed (not available on macOS); "
                 "PyTorch will use CPU/MPS backend",
+                "Removed pytorch channel (available on conda-forge for ARM Mac)",
+                "Relaxed PyTorch <2.0 upper bound (compatible with Sei on ARM Mac)",
             ],
         ),
     },
@@ -186,10 +195,10 @@ PLATFORM_ADAPTATIONS: Dict[str, Dict[str, EnvironmentAdaptation]] = {
         "macos_arm64": EnvironmentAdaptation(
             conda_remove=["pytorch-gpu", "cuda-version"],
             conda_add=["pytorch>=2.0"],
-            channels_remove=["nvidia"],
+            channels_remove=["pytorch", "nvidia"],
             notes=[
                 "Replaced pytorch-gpu with pytorch (no GPU variant on macOS); "
-                "removed CUDA and nvidia channel",
+                "removed CUDA, nvidia and pytorch channels (conda-forge has ARM builds)",
             ],
         ),
     },

--- a/chorus/core/platform.py
+++ b/chorus/core/platform.py
@@ -1,0 +1,302 @@
+"""Platform detection and environment adaptation for cross-architecture support.
+
+Detects the current system architecture and applies necessary dependency
+adjustments to oracle environment YAML configurations. This allows the same
+YAML files (written for Linux x86_64) to work on ARM macOS and other platforms.
+"""
+
+import platform
+import subprocess
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Any
+from copy import deepcopy
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class PlatformInfo:
+    """Detected platform characteristics."""
+    system: str        # 'Darwin', 'Linux', 'Windows'
+    machine: str       # 'arm64', 'x86_64', 'aarch64'
+    is_arm: bool = False
+    is_macos: bool = False
+    is_linux: bool = False
+    has_cuda: bool = False
+
+    @property
+    def key(self) -> str:
+        """Return a platform key for adaptation lookup (e.g. 'macos_arm64')."""
+        os_part = "macos" if self.is_macos else "linux" if self.is_linux else self.system.lower()
+        arch_part = "arm64" if self.is_arm else self.machine
+        return f"{os_part}_{arch_part}"
+
+
+def detect_platform() -> PlatformInfo:
+    """Detect the current platform and its capabilities."""
+    system = platform.system()
+    machine = platform.machine()
+
+    info = PlatformInfo(
+        system=system,
+        machine=machine,
+        is_arm=machine in ('arm64', 'aarch64'),
+        is_macos=system == 'Darwin',
+        is_linux=system == 'Linux',
+    )
+
+    # Check for CUDA availability
+    if info.is_linux:
+        try:
+            result = subprocess.run(
+                ['nvidia-smi'], capture_output=True, text=True, timeout=5
+            )
+            info.has_cuda = result.returncode == 0
+        except (FileNotFoundError, subprocess.TimeoutExpired):
+            info.has_cuda = False
+
+    logger.info(
+        f"Detected platform: {info.system} {info.machine} "
+        f"(key={info.key}, cuda={info.has_cuda})"
+    )
+    return info
+
+
+@dataclass
+class PostInstallStep:
+    """A pip install to run after the conda environment is created."""
+    packages: List[str]
+    flags: List[str] = field(default_factory=list)
+    description: str = ""
+
+
+@dataclass
+class EnvironmentAdaptation:
+    """Describes how to adapt a YAML environment for a specific platform."""
+
+    # Conda-level changes
+    conda_remove: List[str] = field(default_factory=list)
+    conda_add: List[str] = field(default_factory=list)
+
+    # Pip-level changes (matched by package name prefix before ==, >=, etc.)
+    pip_replace: Dict[str, Optional[str]] = field(default_factory=dict)
+    pip_add: List[str] = field(default_factory=list)
+    pip_remove: List[str] = field(default_factory=list)
+
+    # Channels to add/remove
+    channels_remove: List[str] = field(default_factory=list)
+
+    # Post-install pip steps (run after conda env create)
+    post_install: List[PostInstallStep] = field(default_factory=list)
+
+    # Human-readable notes logged during setup
+    notes: List[str] = field(default_factory=list)
+
+
+def _pkg_name(spec: str) -> str:
+    """Extract the package name from a conda/pip spec string.
+
+    Examples:
+        'tensorflow==2.8.0' -> 'tensorflow'
+        'numpy>=1.21.0' -> 'numpy'
+        'protobuf==3.20' -> 'protobuf'
+    """
+    for sep in ('==', '>=', '<=', '!=', '<', '>', '~='):
+        if sep in spec:
+            return spec.split(sep)[0].strip()
+    return spec.strip()
+
+
+# ---------------------------------------------------------------------------
+# Platform adaptation rules per oracle
+# ---------------------------------------------------------------------------
+# Keys are "<oracle_name>": { "<platform_key>": EnvironmentAdaptation, ... }
+# Platform keys follow PlatformInfo.key format (e.g. "macos_arm64").
+#
+# The YAML files in environments/ are the canonical Linux x86_64 definitions.
+# Adaptations here only describe what must change for other platforms.
+# ---------------------------------------------------------------------------
+
+PLATFORM_ADAPTATIONS: Dict[str, Dict[str, EnvironmentAdaptation]] = {
+    "chrombpnet": {
+        "macos_arm64": EnvironmentAdaptation(
+            conda_remove=["protobuf"],
+            conda_add=["igraph", "leidenalg"],
+            pip_replace={
+                "tensorflow": "tensorflow==2.15.1",
+                "tensorflow-probability": "tensorflow-probability==0.23.0",
+                "tensorflow-estimator": None,  # remove, bundled in TF 2.15
+                "modisco-lite": None,  # remove from pip, install post with --no-deps
+            },
+            pip_add=[
+                "protobuf>=3.20.3,<5.0",
+                "hdf5plugin",
+                "numba",
+            ],
+            post_install=[
+                PostInstallStep(
+                    packages=["modisco-lite==2.0.7"],
+                    flags=["--no-deps"],
+                    description=(
+                        "modisco-lite pins old igraph/leidenalg that require "
+                        "source builds on ARM; conda-installed versions are compatible"
+                    ),
+                ),
+            ],
+            notes=[
+                "TensorFlow 2.8 is not available for Apple Silicon; using 2.15.1",
+                "igraph/leidenalg installed via conda to avoid source compilation",
+                "modisco-lite installed with --no-deps to skip pinned igraph build",
+            ],
+        ),
+    },
+    "enformer": {
+        "macos_arm64": EnvironmentAdaptation(
+            pip_replace={
+                "tensorflow": "tensorflow>=2.15.0,<2.17.0",
+            },
+            notes=[
+                "TensorFlow <2.13 is not available for Apple Silicon; "
+                "broadening range to >=2.15",
+            ],
+        ),
+    },
+    "borzoi": {
+        "macos_arm64": EnvironmentAdaptation(
+            conda_remove=["cudatoolkit"],
+            pip_remove=["nvidia::cuda-nvcc"],
+            channels_remove=["nvidia"],
+            notes=[
+                "CUDA packages removed (not available on macOS); "
+                "PyTorch will use CPU/MPS backend",
+            ],
+        ),
+    },
+    "sei": {
+        "macos_arm64": EnvironmentAdaptation(
+            conda_remove=["cudatoolkit"],
+            notes=[
+                "CUDA toolkit removed (not available on macOS); "
+                "PyTorch will use CPU/MPS backend",
+            ],
+        ),
+    },
+    "legnet": {
+        "macos_arm64": EnvironmentAdaptation(
+            conda_remove=["pytorch-gpu", "cuda-version"],
+            conda_add=["pytorch>=2.0"],
+            channels_remove=["nvidia"],
+            notes=[
+                "Replaced pytorch-gpu with pytorch (no GPU variant on macOS); "
+                "removed CUDA and nvidia channel",
+            ],
+        ),
+    },
+}
+
+
+def adapt_environment_config(
+    config: Dict[str, Any],
+    oracle: str,
+    platform_info: PlatformInfo,
+) -> tuple:
+    """Adapt a parsed YAML environment config for the detected platform.
+
+    Args:
+        config: Parsed YAML dict (from yaml.safe_load).
+        oracle: Oracle name (e.g. 'chrombpnet').
+        platform_info: Detected platform information.
+
+    Returns:
+        Tuple of (adapted_config, post_install_steps, notes).
+        adapted_config is a new dict (original is not mutated).
+    """
+    oracle_adaptations = PLATFORM_ADAPTATIONS.get(oracle, {})
+    adaptation = oracle_adaptations.get(platform_info.key)
+
+    if adaptation is None:
+        return config, [], []
+
+    config = deepcopy(config)
+    deps = config.get("dependencies", [])
+
+    # --- Channel removals ---
+    if adaptation.channels_remove and "channels" in config:
+        config["channels"] = [
+            ch for ch in config["channels"]
+            if ch not in adaptation.channels_remove
+        ]
+
+    # --- Separate conda deps and pip section ---
+    conda_deps = []
+    pip_section = None
+    pip_section_idx = None
+
+    for i, dep in enumerate(deps):
+        if isinstance(dep, dict) and "pip" in dep:
+            pip_section = dep["pip"]
+            pip_section_idx = i
+        else:
+            conda_deps.append(dep)
+
+    # --- Apply conda-level removals ---
+    if adaptation.conda_remove:
+        remove_names = set(adaptation.conda_remove)
+        conda_deps = [
+            d for d in conda_deps
+            if _pkg_name(str(d)) not in remove_names
+        ]
+
+    # --- Apply conda-level additions ---
+    for pkg in adaptation.conda_add:
+        if not any(_pkg_name(str(d)) == _pkg_name(pkg) for d in conda_deps):
+            conda_deps.append(pkg)
+
+    # --- Apply pip-level changes ---
+    if pip_section is not None:
+        new_pip = []
+        for spec in pip_section:
+            name = _pkg_name(str(spec))
+
+            # Check if this should be replaced
+            if name in adaptation.pip_replace:
+                replacement = adaptation.pip_replace[name]
+                if replacement is not None:
+                    new_pip.append(replacement)
+                # else: remove (replacement is None)
+                continue
+
+            # Check if this should be removed
+            if name in adaptation.pip_remove:
+                continue
+
+            new_pip.append(spec)
+
+        # Add new pip packages
+        for pkg in adaptation.pip_add:
+            if not any(_pkg_name(str(p)) == _pkg_name(pkg) for p in new_pip):
+                new_pip.append(pkg)
+
+        pip_section = new_pip
+
+    # --- Also remove pip_remove items from conda deps (e.g. 'nvidia::cuda-nvcc') ---
+    if adaptation.pip_remove:
+        remove_set = set(adaptation.pip_remove)
+        conda_deps = [d for d in conda_deps if str(d) not in remove_set]
+
+    # --- Rebuild dependencies list ---
+    new_deps = list(conda_deps)
+    if pip_section is not None:
+        new_deps.append({"pip": pip_section})
+
+    # Ensure 'pip' is in conda deps (needed for pip section)
+    if pip_section is not None:
+        pip_in_conda = any(str(d) == "pip" for d in new_deps if not isinstance(d, dict))
+        if not pip_in_conda:
+            # Insert before pip section
+            new_deps.insert(len(new_deps) - 1, "pip")
+
+    config["dependencies"] = new_deps
+
+    return config, adaptation.post_install, adaptation.notes

--- a/tests/test_smoke_predict.py
+++ b/tests/test_smoke_predict.py
@@ -1,0 +1,133 @@
+"""Smoke tests: instantiate each oracle, load a model, and run predict().
+
+These tests require:
+  - All 5 conda environments set up (chorus setup --oracle <name>)
+  - Reference genome at genomes/hg38.fa
+  - Pretrained model weights downloaded for chrombpnet, sei, and legnet
+
+Run with: pytest tests/test_smoke_predict.py -v -s
+(Use -s to see live output from environment subprocesses.)
+"""
+
+import pytest
+import numpy as np
+import chorus
+
+
+REFERENCE_FASTA = "genomes/hg38.fa"
+
+# Genomic regions on chr1 sized to each oracle's input window
+REGIONS = {
+    "chrombpnet": ("chr1", 1_000_000, 1_002_114),
+    "enformer":   ("chr1", 1_000_000, 1_393_216),
+    "borzoi":     ("chr1", 1_000_000, 1_524_288),
+    "sei":        ("chr1", 1_000_000, 1_004_096),
+    "legnet":     ("chr1", 1_000_000, 1_002_048),
+}
+
+
+@pytest.fixture(scope="module")
+def chrombpnet_oracle():
+    oracle = chorus.create_oracle(
+        "chrombpnet", use_environment=True, reference_fasta=REFERENCE_FASTA
+    )
+    oracle.load_pretrained_model(assay="ATAC", cell_type="K562")
+    return oracle
+
+
+@pytest.fixture(scope="module")
+def enformer_oracle():
+    oracle = chorus.create_oracle(
+        "enformer", use_environment=True, reference_fasta=REFERENCE_FASTA
+    )
+    oracle.load_pretrained_model()
+    return oracle
+
+
+@pytest.fixture(scope="module")
+def borzoi_oracle():
+    oracle = chorus.create_oracle(
+        "borzoi", use_environment=True, reference_fasta=REFERENCE_FASTA
+    )
+    oracle.load_pretrained_model()
+    return oracle
+
+
+@pytest.fixture(scope="module")
+def sei_oracle():
+    oracle = chorus.create_oracle(
+        "sei", use_environment=True, reference_fasta=REFERENCE_FASTA
+    )
+    oracle.load_pretrained_model()
+    return oracle
+
+
+@pytest.fixture(scope="module")
+def legnet_oracle():
+    oracle = chorus.create_oracle(
+        "legnet", use_environment=True, reference_fasta=REFERENCE_FASTA,
+        cell_type="K562",
+    )
+    oracle.load_pretrained_model()
+    return oracle
+
+
+class TestSmokeChrombpnet:
+    def test_predict(self, chrombpnet_oracle):
+        result = chrombpnet_oracle.predict(REGIONS["chrombpnet"])
+        tracks = dict(result.items())
+        assert len(tracks) > 0, "No tracks returned"
+        for name, track in tracks.items():
+            assert track.values.shape[0] > 0, f"Empty values for {name}"
+            assert np.isfinite(track.values).all(), f"Non-finite values in {name}"
+
+
+class TestSmokeEnformer:
+    def test_predict(self, enformer_oracle):
+        result = enformer_oracle.predict(
+            REGIONS["enformer"], assay_ids=["ENCFF413AHU"]
+        )
+        tracks = dict(result.items())
+        assert len(tracks) == 1
+        track = tracks["ENCFF413AHU"]
+        assert track.values.shape == (896,)
+        assert np.isfinite(track.values).all()
+
+
+class TestSmokeBorzoi:
+    def test_predict(self, borzoi_oracle):
+        result = borzoi_oracle.predict(
+            REGIONS["borzoi"], assay_ids=["ENCFF413AHU"]
+        )
+        tracks = dict(result.items())
+        assert len(tracks) == 1
+        track = tracks["ENCFF413AHU"]
+        assert track.values.shape == (6144,)
+        assert np.isfinite(track.values).all()
+
+
+class TestSmokeSei:
+    def test_predict(self, sei_oracle):
+        result = sei_oracle.predict(
+            REGIONS["sei"],
+            assay_ids=["TA#HeLa_Epithelium_Cervix@BTAF1@ID:1"],
+        )
+        tracks = dict(result.items())
+        assert len(tracks) == 1
+        for name, track in tracks.items():
+            assert track.values.shape[0] > 0, f"Empty values for {name}"
+            assert np.isfinite(track.values).all(), f"Non-finite values in {name}"
+
+
+class TestSmokeLegnet:
+    def test_predict(self, legnet_oracle):
+        result = legnet_oracle.predict(REGIONS["legnet"])
+        tracks = dict(result.items())
+        assert len(tracks) > 0, "No tracks returned"
+        for name, track in tracks.items():
+            assert track.values.shape[0] > 0, f"Empty values for {name}"
+            assert np.isfinite(track.values).all(), f"Non-finite values in {name}"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "-s"])


### PR DESCRIPTION
## Summary
- **Platform detection**: New `chorus/core/platform.py` module detects system architecture (ARM/x86_64), OS (macOS/Linux), and CUDA availability at runtime
- **Automatic environment adaptation**: `EnvironmentManager.create_environment()` now adapts conda YAML configs on-the-fly for the detected platform — no separate YAML files needed, Linux x86_64 configs remain the canonical source
- **All 5 oracles supported on Apple Silicon**: chrombpnet (TF 2.15.1), enformer (TF >=2.15 + setuptools pin), borzoi (CUDA removal), sei (channel/version fixes), legnet (pytorch-gpu → pytorch)
- **Smoke tests**: End-to-end predict() tests for all 5 oracles (`tests/test_smoke_predict.py`)

### Key design decisions
- Zero impact on Linux x86_64 — adaptations only apply when `PlatformInfo.key` matches (e.g., `macos_arm64`)
- Environment YAML files are unchanged; all platform-specific logic lives in `PLATFORM_ADAPTATIONS` dict
- Post-install steps support (e.g., `pip install --no-deps` for modisco-lite on ARM)
- Handles blocked `anaconda.org` by removing pytorch/nvidia channels (conda-forge has ARM builds)

## Test plan
- [x] All 5 oracle environments created successfully on Apple Silicon (M-series Mac)
- [x] All 5 oracles pass health checks
- [x] All 5 oracles return valid predictions from `predict()` on genomic regions
- [x] `pytest tests/test_smoke_predict.py -v -s` — 5/5 passed
- [ ] Verify no regression on Linux x86_64 (pass-through, no adaptation applied)

🤖 Generated with [Claude Code](https://claude.com/claude-code)