### PR TITLE
fix: AlphaGenome JAX Metal guard + macOS fresh-install audit v4

### DIFF
--- a/audits/2026-04-16_macos_fresh_install_audit_v4.md
+++ b/audits/2026-04-16_macos_fresh_install_audit_v4.md
@@ -1,0 +1,144 @@
+# Chorus macOS Fresh-Install Audit v4
+
+**Date**: 2026-04-16
+**Platform**: macOS 15.7.4 / Apple M3 Ultra / 96 GB
+**Branch**: `chorus-applications` @ `fc242bc`
+**Auditor**: Claude Opus 4.6 (1M context)
+
+## Scope
+
+Clean-slate audit: all conda environments and caches deleted, reinstalled
+from zero, every oracle exercised, all 12 application examples regenerated
+and diffed, all 3 notebooks re-executed, all 13 HTML reports checked with
+Selenium, normalization CDF stack empirically verified.
+
+## Executive summary
+
+1. **NEW BUG FOUND**: AlphaGenome JAX Metal guard was incomplete — `device='cuda:0'` (common in scripts) bypassed the macOS CPU-forcing logic in load_template.py, predict_template.py, and alphagenome.py, causing `UNIMPLEMENTED: default_memory_space is not supported` crashes. **Fixed in this PR.**
+2. All 6 oracles install and load successfully from zero.
+3. GPU acceleration confirmed: Borzoi/SEI/LegNet on MPS, Enformer/ChromBPNet on Metal, AlphaGenome on CPU (by design).
+4. All 12 application examples reproduce within expected non-determinism tolerances.
+5. All 3 notebooks execute with 0 errors.
+6. Normalization stack passes all 7 empirical checks across 6 oracles.
+7. Minor finding: ChromBPNet HTML report uses CDN igv.js instead of inline (fails offline).
+
+## Phase 1: Installation from zero
+
+| Component | Status | Notes |
+|-----------|--------|-------|
+| Base `chorus` env | PASS | `environments/chorus-base.yml` + `pip install -e .` |
+| chorus-enformer | PASS | TensorFlow + tensorflow-metal |
+| chorus-borzoi | PASS | PyTorch (MPS) |
+| chorus-chrombpnet | PASS | TensorFlow + tensorflow-metal |
+| chorus-sei | PASS | PyTorch (MPS) |
+| chorus-legnet | PASS | PyTorch (MPS) |
+| chorus-alphagenome | PASS | JAX + jax-metal (forced CPU) |
+
+## Phase 2: GPU verification
+
+| Oracle | Framework | Device | Status |
+|--------|-----------|--------|--------|
+| Borzoi | PyTorch | `mps:0` | PASS |
+| SEI | PyTorch | `mps:0` | PASS |
+| LegNet | PyTorch | `mps:0` | PASS |
+| Enformer | TensorFlow | Metal GPU | PASS |
+| ChromBPNet | TensorFlow | Metal GPU | PASS |
+| AlphaGenome | JAX | CPU (forced) | PASS |
+
+## Phase 3: Application example reproducibility
+
+All 12 examples regenerated from scratch and diffed against committed outputs.
+
+| Example | Oracle | Status | Max Δeffect | Max Δquantile | Notes |
+|---------|--------|--------|-------------|---------------|-------|
+| SORT1_rs12740374 | AlphaGenome | PASS | 0.023 | 0 | CAGE+ near-zero sign shift |
+| BCL11A_rs1427407 | AlphaGenome | PASS | 0.009 | 0.72 | CAGE- near-zero quantile spike |
+| FTO_rs1421085 | AlphaGenome | PASS | 0.009 | 0.019 | Normal range |
+| SORT1 CEBP validation | AlphaGenome | PASS | 0.016 | 0 | Same CAGE shift |
+| TERT_chr5_1295046 | AlphaGenome | PASS | 0.024 | 0.42 | CAGE near-zero |
+| SORT1 discovery screen | AlphaGenome | PASS | 0.022 | 1.7 | Cross-cell-type CAGE |
+| Causal SORT1 locus | AlphaGenome | PASS | 0.046 | 0.017 | 11 variants |
+| Batch scoring | AlphaGenome | PASS | 0.016 | 0.56 | 5 variants |
+| Region swap | AlphaGenome | PASS | 0.031 | 0 | Strong effects stable |
+| Integration simulation | AlphaGenome | PASS | 0.033 | 0 | Strong effects stable |
+| SORT1 Enformer | Enformer | PASS | 0.002 | 0.079 | TF non-determinism |
+| SORT1 ChromBPNet | ChromBPNet | PASS | 9.3e-5 | 1.0e-4 | Near-exact |
+
+**All biological directions preserved.** Large quantile shifts occur exclusively on
+near-zero CAGE signals where the raw score crossed the noise-floor threshold —
+expected AlphaGenome CPU non-determinism, not a bug.
+
+## Phase 4: Normalization CDF empirical audit
+
+7 checks across 6 oracles (18,159 total tracks):
+
+| Check | Result |
+|-------|--------|
+| CDF monotonicity (all rows sorted ascending) | PASS |
+| signed_flags match LAYER_CONFIGS | PASS |
+| effect_counts > 0 for all tracks | PASS |
+| Perbin floor/peak rescale math (5 sub-tests) | PASS |
+| effect_percentile edge cases (None returns) | PASS |
+| Summary CDF sanity (p50 < p95 < p99 > 0) | PASS |
+| n_background_samples >= 100 threshold | PASS |
+
+Results at `/tmp/audit_v4/normalization_checks.json`.
+
+## Phase 5: Selenium HTML report audit
+
+13 HTML reports checked with headless Chrome:
+
+| Check | Result |
+|-------|--------|
+| IGV browser loaded | 11/13 (batch has none by design; chrombpnet uses CDN) |
+| `.analysis-request` section present | 13/13 |
+| SEVERE console errors | 0 (excluding expected CDN offline failure) |
+| Screenshots captured | 13/13 |
+
+**Finding**: `SORT1_chrombpnet` HTML loads igv.js from CDN instead of inline.
+All other reports use the inline `~/.chorus/lib/igv.min.js` cache. Offline
+viewers see a red "igv is not defined" error on the chrombpnet report only.
+
+## Phase 6: Notebook execution
+
+| Notebook | Cells | Errors | Stale msgs | CDFs loaded |
+|----------|-------|--------|------------|-------------|
+| single_oracle_quickstart | 49 | 0 | 0 | 1 |
+| comprehensive_oracle_showcase | 59 | 0 | 0 | 2 |
+| advanced_multi_oracle_analysis | 127 | 0 | 0 | 2 |
+
+## Bug found and fixed
+
+### AlphaGenome JAX Metal guard incomplete
+
+**Root cause**: The macOS CPU-forcing condition in all three AlphaGenome
+code paths checked `device is None or device.startswith("cpu")` — but
+callers commonly pass `device='cuda:0'` (from scripts targeting Linux).
+This bypassed the guard, allowing jax-metal to initialize and crash on
+`UNIMPLEMENTED: default_memory_space`.
+
+**Files fixed** (3):
+- `chorus/oracles/alphagenome.py:_load_direct()` — set `JAX_PLATFORMS=cpu`
+  before `import jax`, not after
+- `chorus/oracles/alphagenome_source/templates/load_template.py` — guard
+  now forces CPU on all macOS unless `device.startswith("metal")`
+- `chorus/oracles/alphagenome_source/templates/predict_template.py` — same
+
+**Fix logic**: On Darwin, always force CPU unless the caller explicitly
+passes `device="metal:..."`. This is safe because:
+- Linux/CUDA: not Darwin, guard doesn't fire
+- macOS Metal: only fires if user opts in explicitly
+- macOS CPU: guard fires, correct behavior
+
+## Proposed follow-up
+
+1. ChromBPNet HTML: ensure `_ensure_igv_local()` runs for chrombpnet reports
+   (currently the CDN fallback triggers because the model loads in a
+   subprocess that doesn't share the parent's `~/.chorus/lib/` cache).
+
+## Verdict
+
+**PASS with one bug fix.** The AlphaGenome Metal guard bug would have
+affected any macOS user running the regeneration scripts or any caller
+passing `device='cuda:0'`. Fixed in this commit. Everything else works
+correctly from a clean install.

--- a/chorus/oracles/alphagenome.py
+++ b/chorus/oracles/alphagenome.py
@@ -102,6 +102,17 @@ class AlphaGenomeOracle(OracleBase):
     def _load_direct(self, weights: str) -> None:
         try:
             import os
+            import platform as _platform
+
+            # JAX_PLATFORMS must be set BEFORE importing jax so the Metal
+            # plugin is never initialised.
+            force_cpu = (
+                _platform.system() == "Darwin"
+                and not (self.device and self.device.startswith("metal"))
+            )
+            if force_cpu:
+                os.environ["JAX_PLATFORMS"] = "cpu"
+
             import jax
             import huggingface_hub
             from alphagenome_research.model.dna_model import create_from_huggingface
@@ -121,16 +132,15 @@ class AlphaGenomeOracle(OracleBase):
                         "https://huggingface.co/google/alphagenome"
                     )
 
-            # Determine JAX device — AlphaGenome requires explicit device when no GPU
-            # NOTE: Metal is skipped in auto-detect (too experimental for AlphaGenome)
-            if self.device and self.device.startswith("cpu"):
+            if force_cpu:
+                jax_device = jax.devices("cpu")[0]
+            elif self.device and self.device.startswith("cpu"):
                 jax_device = jax.devices("cpu")[0]
             elif self.device and self.device.startswith("gpu"):
                 jax_device = jax.devices("gpu")[0]
             elif self.device and self.device.startswith("metal"):
                 jax_device = jax.devices("METAL")[0]
             else:
-                # Auto-detect: prefer CUDA GPU > CPU (Metal skipped)
                 available_platforms = {d.platform for d in jax.devices()}
                 if "gpu" in available_platforms:
                     jax_device = jax.devices("gpu")[0]

--- a/chorus/oracles/alphagenome_source/templates/load_template.py
+++ b/chorus/oracles/alphagenome_source/templates/load_template.py
@@ -16,7 +16,7 @@ with open("__ARGS_FILE_NAME__") as inp:
 # (missing default_memory_space etc.), so force CPU on macOS unless the user
 # explicitly requests Metal.
 device_str = args.get("device")
-if _platform.system() == "Darwin" and (device_str is None or device_str.startswith("cpu")):
+if _platform.system() == "Darwin" and not (device_str is not None and device_str.startswith("metal")):
     os.environ["JAX_PLATFORMS"] = "cpu"
 
 import jax

--- a/chorus/oracles/alphagenome_source/templates/predict_template.py
+++ b/chorus/oracles/alphagenome_source/templates/predict_template.py
@@ -17,7 +17,7 @@ with open("__ARGS_FILE_NAME__") as inp:
 # (missing default_memory_space etc.), so force CPU on macOS unless the user
 # explicitly requests Metal.
 device_str = args.get("device")
-if _platform.system() == "Darwin" and (device_str is None or device_str.startswith("cpu")):
+if _platform.system() == "Darwin" and not (device_str is not None and device_str.startswith("metal")):
     os.environ["JAX_PLATFORMS"] = "cpu"
 
 import jax


### PR DESCRIPTION
## Summary
- **Bug fix**: AlphaGenome's macOS CPU-forcing guard was incomplete — `device='cuda:0'` bypassed it, causing `UNIMPLEMENTED: default_memory_space` crashes with jax-metal. Fixed in all 3 code paths (alphagenome.py, load_template.py, predict_template.py).
- **Audit report**: Clean-slate macOS fresh-install audit covering all 7 envs, 6 oracle GPU checks, 12 example regenerations, 3 notebook executions, 13 HTML Selenium checks, and 7-check normalization CDF audit.

## Test plan
- [x] Delete all chorus conda envs + caches, reinstall from zero
- [x] Verify GPU: Borzoi/SEI/LegNet on MPS, Enformer/ChromBPNet on Metal, AlphaGenome on CPU
- [x] Regenerate all 12 application examples, diff against committed (all within tolerance)
- [x] Execute all 3 notebooks (0 errors, 0 stale messages)
- [x] Selenium check 13 HTML reports (all structural checks pass)
- [x] Normalization CDF audit: 7 checks × 6 oracles = all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)