### PR TITLE
v16: fix drifted oracle specs + broken walkthroughs/ link in notebooks

### DIFF
--- a/audits/2026-04-21_v16_notebook_and_html_audit.md
+++ b/audits/2026-04-21_v16_notebook_and_html_audit.md
@@ -1,0 +1,87 @@
+# v16 notebook + HTML report walkthrough — 2026-04-21
+
+Walked the three `examples/notebooks/*.ipynb` cell-by-cell (every cell's
+source **and** execution output) and screenshotted eight of the shipped
+`examples/walkthroughs/**/*.html` reports via headless Chrome. Goal: catch
+anything a new user would see that is inconsistent, wrong, or confusing.
+
+## Fixed in this PR
+
+1. **Broken link in both multi-oracle notebooks.** Cell 0 of
+   `comprehensive_oracle_showcase.ipynb` and
+   `advanced_multi_oracle_analysis.ipynb` said
+   `[`examples/walkthroughs/`](applications/)`. The label was correct
+   but the URL still pointed at the old `applications/` directory (renamed
+   to `walkthroughs/` in `340f30e`). Fixed to `../walkthroughs/`.
+2. **AlphaGenome track count drift.** Markdown in
+   `comprehensive_oracle_showcase.ipynb` claimed "5,930 tracks across 11
+   modalities" in three places (overview table, section 6 preamble, and a
+   code comment in Operation 8). The running notebook prints
+   `Loaded 5731 AlphaGenome tracks` and `Assay types: 7`. Fixed to
+   "5,731 tracks" / "7 assay types" everywhere, and added PRO-CAP to the
+   assay list in the overview table so it matches what `list_assay_types()`
+   actually returns (`ATAC, CAGE, CHIP, DNASE, PRO_CAP, RNA, SPLICE_SITES`).
+3. **Enformer context-window typo.** `advanced_multi_oracle_analysis.ipynb`
+   cell 9 called Enformer "a state-of-the-art sequence-to-activity model
+   that can predict **5.313 human genomic tracks** with a context window
+   of 196 kbp". The library reports `oracle.sequence_length == 393216` —
+   matches the comprehensive notebook's summary table (393 kb input). Also
+   fixed the decimal separator (`5.313` → `5,313`). Changed to "393 kbp".
+
+## Not fixed here — flagged for a follow-up
+
+**Off-by-one in `predict_variant_effect`'s ref-allele check.** Both
+`single_oracle_quickstart.ipynb` (cell 39) and
+`comprehensive_oracle_showcase.ipynb` (cell 35) ship an execution output
+that contains
+
+    WARNING - Provided reference allele 'C' does not match the genome at
+    this position ('T'). Chorus will use the provided allele.
+
+for the test variant at `chrX:48786129`. The notebook code pulls the ref
+base via `extract_sequence('chrX:48786129-48786129')` which returns `'C'`
+(matches every external reference — UCSC, dbSNP, hg38 FASTA). But inside
+`chorus/core/base.py:322-328`:
+
+    real_pos = region_interval.ref2query(var_pos, ref_global=True)
+    if region_interval[real_pos].upper() != ref_allele.upper():
+        logger.warning(...)
+
+the internal check reads the **next** base (`'T'`) instead of `'C'`. Same
+shift reproduces for the rs12740374 example: `chr1:109274968` is `G` by
+every external reference (and by `extract_sequence`), but
+`region_interval[ref2query(109274968, ref_global=True)]` returns `'T'`
+(the base at 109274969).
+
+Consequence of the bug: every variant analysis in the shipped walkthroughs
+logs this warning even when the user provided the correct allele. More
+seriously, the reference allele substitution at line 330 happens at the
+shifted position, so the ref/alt predictions are computed at one base off
+the user's intended coordinate. Predicted effect *directions* still come
+out right (the walkthroughs all agree with Musunuru et al. 2010 for
+rs12740374), which is probably why this has been shipping unnoticed — the
+regulatory signal is coherent across ±1 bp in every case the library
+tests on.
+
+Not fixing in this PR because it's a code-behaviour change (not a doc
+drift), and because any fix needs to be audited against what happens at
+indels and reverse-strand variants, not just SNVs. Best handled as its own
+focused PR.
+
+## HTML reports screenshotted
+
+Rendered at 1400×3000 via Chrome --headless and eye-reviewed. Nothing
+report-level was wrong:
+
+- `walkthroughs/validation/SORT1_rs12740374_multioracle/rs12740374_SORT1_multioracle_report.html`
+- `walkthroughs/variant_analysis/SORT1_rs12740374/rs12740374_SORT1_alphagenome_report.html`
+- `walkthroughs/causal_prioritization/SORT1_locus/rs12740374_SORT1_locus_causal_report.html`
+- `walkthroughs/batch_scoring/batch_sort1_locus_scoring.html`
+- `walkthroughs/discovery/SORT1_cell_type_screen/chr1_109274968_G_T_SORT1_alphagenome_LNCaP_clone_FGC_report.html`
+- `walkthroughs/sequence_engineering/region_swap/region_swap_SORT1_K562_report.html`
+- `walkthroughs/validation/SORT1_rs12740374_with_CEBP/rs12740374_SORT1_CEBP_validation_report.html`
+
+All display the glossary, formula chips, cross-layer tables, and
+(client-side JS) IGV browser placeholder correctly. The embedded IGV
+itself doesn't render in headless file:// mode — not a bug, it's a
+loader limitation for local previews.

--- a/examples/notebooks/advanced_multi_oracle_analysis.ipynb
+++ b/examples/notebooks/advanced_multi_oracle_analysis.ipynb
@@ -27,7 +27,7 @@
     "> uses only Enformer and runs end-to-end with a single `chorus setup` call.\n",
     ">\n",
     "> For **variant analysis** use-cases (the most common end-user task), the\n",
-    "> [`examples/walkthroughs/`](applications/) folder has ready-to-run MCP + Claude\n",
+    "> [`examples/walkthroughs/`](../walkthroughs/) folder has ready-to-run MCP + Claude\n",
     "> examples that do not require any notebook at all.\n"
    ]
   },
@@ -206,7 +206,7 @@
    "id": "f9d58537",
    "metadata": {},
    "source": [
-    "**Oracles** are the main objects in Chorus. They manages models that can make predictions on the genome. Let's start by downloading [Enformer](https://www.nature.com/articles/s41592-021-01252-x), a state-of-the-art sequence-to-activity models that can predict **5.313 human genomic tracks** with a context window of 196 kbp."
+    "**Oracles** are the main objects in Chorus. They manages models that can make predictions on the genome. Let's start by downloading [Enformer](https://www.nature.com/articles/s41592-021-01252-x), a state-of-the-art sequence-to-activity models that can predict **5,313 human genomic tracks** with an input window of 393 kbp."
    ]
   },
   {

--- a/examples/notebooks/comprehensive_oracle_showcase.ipynb
+++ b/examples/notebooks/comprehensive_oracle_showcase.ipynb
@@ -27,7 +27,7 @@
     "> uses only Enformer and runs end-to-end with a single `chorus setup` call.\n",
     ">\n",
     "> For **variant analysis** use-cases (the most common end-user task), the\n",
-    "> [`examples/walkthroughs/`](applications/) folder has ready-to-run MCP + Claude\n",
+    "> [`examples/walkthroughs/`](../walkthroughs/) folder has ready-to-run MCP + Claude\n",
     "> examples that do not require any notebook at all.\n"
    ]
   },
@@ -47,7 +47,7 @@
     "| **ChromBPNet** | TensorFlow | 2 kb | 1 bp | Per-model (DNASE, ATAC) |\n",
     "| **Sei** | PyTorch | 4 kb | 128 bp | 21,907 (histone marks, TF binding, sequence classes) |\n",
     "| **LegNet** | PyTorch | 230 bp | 1 bp | 1 (LentiMPRA) |\n",
-    "| **AlphaGenome** | JAX | 1 Mb | 1 bp | 5,930 (DNASE, CAGE, CHIP, ATAC, RNA, splice sites) |\n",
+    "| **AlphaGenome** | JAX | 1 Mb | 1 bp | 5,731 (DNASE, CAGE, CHIP, ATAC, RNA, PRO-CAP, splice sites) |\n",
     "\n",
     "**Operations demonstrated:**\n",
     "1. Wild-type prediction (`predict`)\n",
@@ -1052,7 +1052,7 @@
     "---\n",
     "## 6. AlphaGenome — JAX, 1 Mb context, single bp resolution\n",
     "\n",
-    "AlphaGenome (Google DeepMind, Nature 2026) is the latest and most comprehensive genomics model. It predicts 5,930 tracks across 11 modalities at single base-pair resolution from up to 1 Mb of DNA sequence."
+    "AlphaGenome (Google DeepMind, Nature 2026) is the latest and most comprehensive genomics model. It predicts 5,731 tracks across 7 assay types at single base-pair resolution from up to 1 Mb of DNA sequence."
    ]
   },
   {
@@ -2228,7 +2228,7 @@
    ],
    "source": [
     "# Step 1: Select biologically appropriate hepatocyte tracks from AlphaGenome\n",
-    "# AlphaGenome has 5,930 tracks — we need liver-relevant ones for an LDL cholesterol variant\n",
+    "# AlphaGenome has 5,731 tracks — we need liver-relevant ones for an LDL cholesterol variant\n",
     "\n",
     "ag_hepatocyte_tracks = {\n",
     "    # Layer 1: Chromatin accessibility\n",


### PR DESCRIPTION
## Summary

Read every cell output of the three library notebooks and screenshotted 8 of the shipped HTML reports via headless Chrome. Found three drifts a new user would trip on, plus one latent code bug I'm **not** fixing here but flagging for a focused follow-up.

### Fixed

- **Broken `applications/` link** in `comprehensive_oracle_showcase.ipynb` and `advanced_multi_oracle_analysis.ipynb` cell 0. The dir was renamed to `walkthroughs/` in `340f30e`; the URL still pointed at the old path. Retargeted to `../walkthroughs/`.
- **AlphaGenome spec drift** in `comprehensive_oracle_showcase.ipynb` — overview table, section 6 preamble, and the Operation 8 comment all said `5,930 tracks across 11 modalities`. The running notebook prints `Loaded 5731 AlphaGenome tracks` and `Assay types: 7 ['ATAC', 'CAGE', 'CHIP', 'DNASE', 'PRO_CAP', 'RNA', 'SPLICE_SITES']`. Corrected to `5,731` / `7 assay types` and added PRO-CAP to the assay list.
- **Enformer context-window typo** in `advanced_multi_oracle_analysis.ipynb` cell 9 (`196 kbp` → `393 kbp`) to match `oracle.sequence_length` and the comprehensive notebook's summary table. Also `5.313` → `5,313` (decimal separator).

### Flagged, not fixed — needs its own PR

**`predict_variant_effect` ref-allele check is off by one** (`chorus/core/base.py:322-328`). `extract_sequence('chr1:109274968-109274968')` returns `'G'` (matches dbSNP/UCSC); `region_interval[ref2query(109274968, ref_global=True)]` returns `'T'` (the base at 109274969). Every shipped walkthrough logs a harmless-looking warning *and* substitutes the ref/alt one base off. Published mechanism for rs12740374 still reproduces because the regulatory signal is coherent across ±1 bp, which is why this has flown under the radar. Full reproduction trace in `audits/2026-04-21_v16_notebook_and_html_audit.md`.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_smoke_predict.py -q` → 333 passed / 1 skipped (8m 38s)
- [x] `python -c 'import nbformat; [nbformat.read(p, 4) for p in …]'` — all 3 notebooks round-trip clean
- [x] `grep '5,930\|11 modalities\|196 kbp\|applications/)' examples/notebooks/*.ipynb` → no matches
- [x] Screenshotted 8 HTML reports at 1400×3000; verified glossary / formula chips / tables render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)