### PR TITLE
v17 full audit: MCP server spec drift + Borzoi/LegNet numbers + CEBP walkthrough

### DIFF
--- a/audits/2026-04-21_v17_full_audit.md
+++ b/audits/2026-04-21_v17_full_audit.md
@@ -1,0 +1,92 @@
+# v17 comprehensive audit — 2026-04-21
+
+A full "ship-ready" pass: docs consistency (live docs only), walkthrough
+numbers vs committed outputs, all 17 shipped HTML reports, hands-on
+Python API / MCP / error-message / device-detection exercise.
+
+## Method
+
+- **Docs sweep** — read every `README.md` / `docs/*.md` / `scripts/README.md`
+  / `AUDIT_PROMPT.md` / MCP server tool descriptions. Cross-checked every
+  track count and oracle spec against what the library actually returns
+  (`create_oracle(...).sequence_length`, `.get_track_info()`,
+  `len(ag_meta._track_index_map)`).
+- **Walkthroughs** — cross-checked numbers in each `README.md` against its
+  companion `example_output.md` / `.json`. Accepted ±0.005 drift as CPU
+  non-determinism, flagged larger gaps.
+- **HTML reports** — screenshotted all 17 `examples/walkthroughs/**/*.html`
+  at 1400×2800 via headless Chrome and eye-checked each one for label
+  leaks, formula drift, missing sections, or broken layout.
+- **Python API** — exercised `create_oracle` with good/bad inputs,
+  `ModelNotLoadedError` path, invalid oracle name, empty oracle name.
+- **MCP server** — imported `chorus.mcp.server`, walked its registered
+  tool list (22 tools) via the internal FastMCP registry.
+- **Device/platform** — `detect_platform()` on macOS arm64 returns
+  `key=macos_arm64, has_cuda=False`. Each oracle env handles its own
+  backend (MPS/TF Metal/JAX-CPU), which is the intended design.
+
+## Fixed in this PR
+
+1. **`chorus/mcp/server.py:77`** — AlphaGenome description said
+   `"1-bp resolution across 5930 tracks"`. Real count is 5,731 (matches
+   what `list_oracles()` prints and what the notebooks were fixed to in
+   v16). Updated to `5,731`.
+
+2. **`chorus/mcp/server.py:1482`** — the MCP system prompt that the
+   server ships to the AI assistant said
+   `"AlphaGenome: 1Mb window, 5930 tracks, 1bp resolution"`. Same fix:
+   `5,731`. Also added the explicit `7,611 tracks` count for Borzoi on
+   the adjacent line so a new Claude session using Chorus via MCP gets
+   consistent numbers.
+
+3. **`chorus/mcp/server.py:71`** — LegNet `"input_size_bp": 230` was
+   stale. `create_oracle('legnet').sequence_length` returns 200. Updated
+   to 200.
+
+4. **`scripts/README.md:37, 94`** — Borzoi `"7,612"` in the background
+   build-script table and the output directory example. Real count from
+   `get_track_info()` summed across assay types is 7,611. Fixed both.
+
+5. **`examples/walkthroughs/validation/SORT1_rs12740374_with_CEBP/README.md:21`** —
+   "CEBPB binding gain: +0.22 (moderate)" but the committed
+   `example_output.md` line 31 shows `+0.270`. 0.05 gap is beyond CPU
+   non-determinism. Corrected to `+0.27`.
+
+## What else was checked and is clean
+
+- **Every other number** in every walkthrough README is either an exact
+  match with the committed `example_output.md` or within ±0.006 (accept
+  as CPU non-det).
+- **Formula labels** everywhere: chromatin/TF/histone/TSS rows carry
+  `log2FC`; gene-expression rows carry `lnFC`; MPRA rows carry
+  `Δ (alt−ref)`. Zero rogue labels.
+- **Links** — no live file references the old `examples/applications/`
+  path (only `audits/` snapshots do, which is intentional).
+- **All 17 HTMLs** render with the glossary, formula chips, consensus
+  matrix, per-layer tables, and IGV browser placeholder (IGV itself is
+  client-side JS and doesn't render in headless file:// — not a bug).
+- **Error messages**:
+  - `create_oracle('fakeOracle')` → `ValueError: Unknown oracle: fakeoracle. Available: ['enformer', 'borzoi', 'chrombpnet', 'sei', 'legnet', 'alphagenome']` ✓
+  - `predict()` without `load_pretrained_model()` → clear
+    `ModelNotLoadedError: Model not loaded. Call load_pretrained_model first.` ✓
+- **Platform detection** correctly identifies macOS arm64 and falls
+  back to per-oracle-env device selection. No bogus CUDA detection
+  attempts on Mac.
+- **MCP tool registry** — 22 tools all named consistently with the
+  walkthrough READMEs. No dead / renamed tools.
+
+## Known latent issues, NOT fixed here
+
+- **Off-by-one in `predict_variant_effect` ref-allele check**
+  (`chorus/core/base.py:322-328`) — tracked in
+  `audits/2026-04-21_v16_notebook_and_html_audit.md`. Still needs a
+  focused code PR with SNV + indel + reverse-strand coverage.
+- **NumExpr "safe limit of 16"** warning on every chorus import. This is
+  a numexpr / matplotlib upstream thing, not a Chorus bug.
+- **Notebook shipped outputs contain `/srv/local/lp698/...` paths** —
+  cosmetic, author's machine.
+
+## Test status
+
+`pytest tests/ --ignore=tests/test_smoke_predict.py -q` → 333 passed /
+1 skipped on this branch.

--- a/chorus/mcp/server.py
+++ b/chorus/mcp/server.py
@@ -68,13 +68,13 @@ ORACLE_SPECS = {
     "legnet": {
         "description": "LegNet — MPRA activity prediction",
         "framework": "PyTorch",
-        "input_size_bp": 230,
+        "input_size_bp": 200,
         "output_bins": 1,
         "resolution_bp": None,
         "assay_types": ["LentiMPRA"],
     },
     "alphagenome": {
-        "description": "AlphaGenome (DeepMind) — 1-bp resolution across 5930 tracks",
+        "description": "AlphaGenome (DeepMind) — 1-bp resolution across 5,731 tracks",
         "framework": "JAX",
         "input_size_bp": 1_048_576,
         "output_bins": 1_048_576,
@@ -1479,9 +1479,9 @@ def getting_started() -> str:
         "1. **Discover oracles**: Call `list_oracles()` to see all 6 available oracles "
         "and which ones have their environments installed.\n\n"
         "2. **Choose an oracle**:\n"
-        "   - **AlphaGenome** (recommended): 1Mb window, 5930 tracks, 1bp resolution. Best for variant analysis.\n"
-        "   - **Enformer**: 114kb output, 5313 ENCODE tracks. Great general-purpose oracle.\n"
-        "   - **Borzoi**: 196kb output at 32bp resolution. Good for distal gene expression.\n"
+        "   - **AlphaGenome** (recommended): 1Mb window, 5,731 tracks, 1bp resolution. Best for variant analysis.\n"
+        "   - **Enformer**: 114kb output, 5,313 ENCODE tracks. Great general-purpose oracle.\n"
+        "   - **Borzoi**: 196kb output at 32bp resolution, 7,611 tracks. Good for distal gene expression.\n"
         "   - **ChromBPNet**: 1bp resolution, 1kb window. Best for motif-level TF binding analysis.\n"
         "   - **Sei**: Regulatory element classification (not per-track signal).\n"
         "   - **LegNet**: MPRA activity prediction for short sequences.\n\n"

--- a/examples/walkthroughs/validation/SORT1_rs12740374_with_CEBP/README.md
+++ b/examples/walkthroughs/validation/SORT1_rs12740374_with_CEBP/README.md
@@ -18,7 +18,7 @@ expression changes.
 
 The AlphaGenome prediction reproduces the published mechanism:
 - CEBPA binding gain: +0.37 (strong)
-- CEBPB binding gain: +0.22 (moderate)
+- CEBPB binding gain: +0.27 (moderate)
 - DNASE opening: +0.43 (strong)
 - H3K27ac activation: +0.18 (moderate)
 

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -34,7 +34,7 @@ Use `--part all` to run everything sequentially on a single GPU.
 | Script | Oracle | Tracks | Env | Runtime (single GPU) |
 |--------|--------|--------|-----|---------------------|
 | `build_backgrounds_enformer.py` | Enformer | 5,313 | `chorus-enformer` | ~4h variants + ~7h baselines |
-| `build_backgrounds_borzoi.py` | Borzoi | 7,612 | `chorus-borzoi` | ~4h + ~9h |
+| `build_backgrounds_borzoi.py` | Borzoi | 7,611 | `chorus-borzoi` | ~4h + ~9h |
 | `build_backgrounds_alphagenome.py` | AlphaGenome | ~5,168 | `chorus-alphagenome` | ~10h + ~12h |
 | `build_backgrounds_chrombpnet.py` | ChromBPNet | 24 (per-model) | `chorus-chrombpnet` | ~25 min total |
 | `build_backgrounds_sei.py` | Sei | 40 classes | `chorus-sei` | ~6h + ~8h |
@@ -91,7 +91,7 @@ each SNP:
 ```
 ~/.chorus/backgrounds/
   enformer_pertrack.npz       # 5,313 tracks, ~550 MB
-  borzoi_pertrack.npz         # 7,612 tracks
+  borzoi_pertrack.npz         # 7,611 tracks
   alphagenome_pertrack.npz    # ~5,168 tracks
   chrombpnet_pertrack.npz     # 24 models, 2.4 MB
   sei_pertrack.npz            # 40 classes


### PR DESCRIPTION
## Summary

A comprehensive ship-ready audit: every live doc, every walkthrough README vs its committed `example_output`, all **17 shipped HTML reports screenshotted** via headless Chrome, the Python API, the `chorus-mcp` tool registry, error messages, and macOS-arm64 device detection.

## Five drifts fixed

1. **`chorus/mcp/server.py:77`** (ORACLE_SPECS) — AlphaGenome "**5930** tracks" → **5,731** (matches `list_oracles()` output and the notebooks after v16).
2. **`chorus/mcp/server.py:1482`** (MCP system prompt) — same "5930" → "5,731". Also added `7,611 tracks` explicitly for Borzoi so a Claude session using `chorus-mcp` gets consistent numbers.
3. **`chorus/mcp/server.py:71`** — LegNet `input_size_bp: 230` → **200** (actual `create_oracle('legnet').sequence_length == 200`).
4. **`scripts/README.md:37, 94`** — Borzoi "7,612" → **7,611** (real count summed across assay types via `get_track_info()`).
5. **`examples/walkthroughs/validation/SORT1_rs12740374_with_CEBP/README.md:21`** — "CEBPB binding gain: +0.22" → **+0.27** (committed `example_output.md` line 31 shows `+0.270`; 0.05 gap is beyond CPU non-det).

## What else was checked and is clean

- **Every other walkthrough number** is either an exact match with the companion `example_output.md` or within ±0.006 (accept as CPU non-det).
- **Every formula label**: chromatin/TF/histone/TSS → `log2FC`; gene expression → `lnFC`; MPRA → `Δ (alt−ref)`. Zero rogue labels.
- **17 HTML reports** render with glossary, formula chips, consensus matrix, per-layer tables, IGV placeholder. IGV itself is client-side JS and doesn't render in headless `file://` — expected.
- **Error paths**: `create_oracle('fakeOracle')` → helpful `ValueError` with the valid list; `predict()` without load → clear `ModelNotLoadedError`.
- **MCP tool registry** — 22 tools, all naming matches what the walkthroughs reference.
- **Platform detection on macOS arm64** — `detect_platform()` returns `key=macos_arm64, has_cuda=False`; each oracle env handles its own backend (MPS/TF Metal/JAX-CPU) by design.
- **Zero live references** to the old `examples/applications/` path (only `audits/` snapshots still mention it, which is intentional).

## Known latent issues, NOT fixed here

- **Off-by-one in `predict_variant_effect` ref-allele check** (`chorus/core/base.py:322-328`) — tracked in `audits/2026-04-21_v16_notebook_and_html_audit.md`. Needs its own focused code PR with SNV + indel + reverse-strand coverage.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_smoke_predict.py -q` → **333 passed / 1 skipped** (9m 9s)
- [x] Screenshotted all 17 HTMLs at 1400×2800 and reviewed each for label/formula/layout drift
- [x] `python -c 'from chorus.mcp.server import mcp; import asyncio; print(len(asyncio.run(mcp._list_tools())))'` → 22 tools
- [x] `python -c 'import chorus; chorus.create_oracle(\"fakeOracle\", use_environment=False)'` raises the expected `ValueError` with the valid list

🤖 Generated with [Claude Code](https://claude.com/claude-code)