### PR TITLE
Fix off-by-one in predict_variant_effect ref-allele check

### DIFF
--- a/chorus/core/base.py
+++ b/chorus/core/base.py
@@ -295,19 +295,31 @@ class OracleBase(ABC):
                     "initialize oracle with reference_fasta."
                 )
         
-        # Parse inputs
+        # Parse inputs.
+        #
+        # Convention: string-form `genomic_region` ("chr1:S-E") and
+        # `variant_position` ("chr1:P") are 1-based inclusive, matching
+        # dbSNP/UCSC/IGV/`extract_sequence`. GenomeRef is 0-based
+        # half-open (see chorus/core/interval.py:26), so we convert when
+        # building the interval and when looking up the variant base.
+        # Without this conversion the ref-allele check reads the base one
+        # position to the right of what the user intended (rs12740374 at
+        # chr1:109274968 returned 'T' instead of 'G').
         region_chrom, region_start, region_end = self._parse_region(genomic_region)
         var_chrom, var_pos = self._parse_position(variant_position)
-        
+
         if region_chrom != var_chrom:
             raise InvalidRegionError("Variant and region must be on the same chromosome")
-        
-        if not (region_start <= var_pos < region_end):
+
+        if not (region_start <= var_pos <= region_end):
             raise InvalidRegionError("Variant position must be within the specified region")
-        
-        region_interval = Interval.make(GenomeRef(chrom=region_chrom, 
-                                                  start=region_start, 
-                                                  end=region_end, 
+
+        region_start_0based = region_start - 1  # 1-based inclusive → 0-based
+        var_pos_0based = var_pos - 1            # 1-based → 0-based
+
+        region_interval = Interval.make(GenomeRef(chrom=region_chrom,
+                                                  start=region_start_0based,
+                                                  end=region_end,
                                                   fasta=genome))
 
         # Parse alleles
@@ -317,9 +329,9 @@ class OracleBase(ABC):
         else:
             ref_allele = alleles[0]
             alt_alleles = alleles[1:]
-        
+
         intervals = {}
-        real_pos = region_interval.ref2query(var_pos, ref_global=True)
+        real_pos = region_interval.ref2query(var_pos_0based, ref_global=True)
         # Case-insensitive compare: pyfaidx returns lowercase for softmasked
         # (repetitive) regions, users always pass uppercase.
         if region_interval[real_pos].upper() != ref_allele.upper():

--- a/tests/test_prediction_methods.py
+++ b/tests/test_prediction_methods.py
@@ -199,6 +199,58 @@ class TestPredictionMethods:
         assert "alt_3" in results["predictions"]
         assert len(results["effect_sizes"]) == 3
 
+    def test_variant_position_is_1_based(self, caplog):
+        """Ref-allele check must treat `variant_position='chrN:P'` as 1-based.
+
+        Builds a chr1 genome where position 100,000 (1-based) is 'G' and the
+        two neighbouring positions are 'A'. The oracle must read 'G' at
+        chr1:100000 and not fire the "does not match the genome" warning.
+        Regression for the off-by-one that returned the base at 1-based
+        P+1 (so rs12740374 returned 'T' instead of 'G').
+        """
+        import logging
+        # Build a custom genome: 'A' everywhere except a 'G' anchor
+        tmp = Path(tempfile.mkdtemp())
+        fa = tmp / "anchor.fa"
+        # 1-based position 100000 = 0-based 99999.
+        # Pad with A, put G at 99999, A elsewhere, over 200 kb total.
+        seq = ['A'] * 200_000
+        seq[99_999] = 'G'  # 1-based pos 100000
+        with open(fa, "w") as fh:
+            fh.write(">chr1\n" + "".join(seq) + "\n")
+        import pysam
+        pysam.faidx(str(fa))
+
+        oracle = MockOracle(reference_fasta=str(fa))
+
+        # Provide ref='G' matching the genome — warning must NOT fire.
+        with caplog.at_level(logging.WARNING, logger="chorus.core.base"):
+            oracle.predict_variant_effect(
+                genomic_region="chr1:50000-150000",
+                variant_position="chr1:100000",
+                alleles=["G", "A"],
+                assay_ids=["DNase:K562"],
+            )
+        matching = [r for r in caplog.records if "does not match the genome" in r.getMessage()]
+        assert not matching, (
+            f"Warning fired unexpectedly — ref-allele check is off-by-one again. "
+            f"Messages: {[r.getMessage() for r in matching]}"
+        )
+
+        # And with the WRONG ref — warning MUST fire (proves the check still works).
+        caplog.clear()
+        with caplog.at_level(logging.WARNING, logger="chorus.core.base"):
+            oracle.predict_variant_effect(
+                genomic_region="chr1:50000-150000",
+                variant_position="chr1:100000",
+                alleles=["T", "A"],  # genome has G, user says T → mismatch
+                assay_ids=["DNase:K562"],
+            )
+        matching = [r for r in caplog.records if "does not match the genome" in r.getMessage()]
+        assert matching, "Warning should fire when user's ref really doesn't match genome"
+
+        shutil.rmtree(tmp)
+
     def test_error_handling_model_not_loaded(self):
         """Test error when model not loaded."""
         unloaded_oracle = MockOracle(reference_fasta=str(self.fasta_path))


### PR DESCRIPTION
## Problem

The ref-allele sanity check at `chorus/core/base.py:322` was reading the base **one position to the right** of what the user asked for. So

```python
predict_variant_effect(
    genomic_region="chr1:109274000-109275000",
    variant_position="chr1:109274968",
    alleles=["G", "T"],       # rs12740374, as in dbSNP/UCSC
    ...
)
```

triggered

```
WARNING  Provided reference allele 'G' does not match the genome at this
         position ('T'). Chorus will use the provided allele.
```

even though **`G` at chr1:109274968** is exactly what dbSNP/UCSC/IGV/`extract_sequence('chr1:109274968-109274968')` all say. The substitution at line 335 then placed the ref/alt base at pos+1, so every shipped walkthrough was computing predictions at the wrong coordinate. The regulatory signal happens to be coherent across ±1 bp on rs12740374, rs1421085, rs1427407 etc., so effect *directions* still reproduced — which is why this has been shipping.

## Root cause

- `genomic_region` / `variant_position` **strings** follow dbSNP/UCSC/IGV and `chorus.utils.extract_sequence` — **1-based inclusive**.
- `GenomeRef` uses **0-based half-open** (documented at `interval.py:26`).
- `predict_variant_effect` handed the 1-based values straight to `GenomeRef` and to `ref2query`, conflating the two conventions.

## Fix

Convert `region_start` and `var_pos` to 0-based at the point we build the `Interval`. That's it — just two `-1`s with an explanatory comment.

## Verification

Tested against **7 famous SNPs** — for every one, the internal ref-check now agrees with `extract_sequence` and dbSNP:

| rsID | Gene | hg38 | dbSNP ref | internal (before) | internal (after) |
|------|------|------|-----------|--------------------|-------------------|
| rs12740374 | SORT1 | chr1:109274968 | G | **T** | G ✓ |
| rs1421085 | FTO | chr16:53767042 | T | **A** | T ✓ |
| rs1427407 | BCL11A | chr2:60718347 | G | **C** | G ✓ |
| rs4988235 | LCT | chr2:135851076 | G (+ strand) | **C** | G ✓ |
| rs334 | HBB | chr11:5227002 | T (+ strand) | **C** | T ✓ |
| rs6025 | F5 Leiden | chr1:169519049 | T (+ strand) | **C** | T ✓ |
| rs7412 | APOE | chr19:44908822 | C | **G** | C ✓ |

Also works for the MCP `_auto_region` case (a 2 bp region exactly spanning the variant) — the old code silently read pos+1; the fix correctly lands on pos.

## New regression test

`tests/test_prediction_methods.py::test_variant_position_is_1_based` builds a synthetic genome with a single `G` anchor at 1-based position 100,000 and asserts:
- **no warning** when the user passes `ref='G'`
- warning **does** fire when the user passes `ref='T'` (proves the check still catches real mismatches — we haven't just silenced it)

## Scope

Only `predict_variant_effect` is touched. `predict_region_replacement` and `predict_region_insertion_at` also treat their string coordinates as 0-based half-open internally; changing *those* would silently shift existing sequence-engineering results by 1 bp, so that's deferred to a separate PR with example-output regeneration.

## Downstream consequence

Variant effect predictions will now substitute the ref/alt base at the correct 1-based position. Effect sizes in the shipped walkthroughs may drift by a small amount relative to the currently committed `example_output.*` files (±1 bp shift in where the substitution lands). Recommend regenerating those in a follow-up once this merges — the effect direction and magnitudes should stay within CPU non-determinism for AlphaGenome, and will likely shift more noticeably for ChromBPNet (1 bp native resolution) where a 1-bp shift lands on a different bin.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_smoke_predict.py -q` → **334 passed / 1 skipped** (up from 333 — the new test)
- [x] Manual check against 7 famous SNPs — all consistent
- [x] Regression test validates both the fixed path and the still-working mismatch path

🤖 Generated with [Claude Code](https://claude.com/claude-code)