### PR TITLE
Fix bad-chromosome KeyError + last 7,612 drift (v20 §14.4 P1)

### DIFF
--- a/chorus/core/interval.py
+++ b/chorus/core/interval.py
@@ -49,8 +49,22 @@ class GenomeRef:
 
     def slop(self, extension_needed: int, how: str = 'both') ->  'GenomeRef':
         with pysam.FastaFile(self.fasta) as fasta:
-            # Get chromosome length
-            chrom_length = fasta.get_reference_length(self.chrom)
+            # Get chromosome length. pysam raises KeyError(chrom) if the
+            # reference doesn't contain this contig — catch and re-raise
+            # as InvalidRegionError so users get an actionable message
+            # (naming the bad chromosome and the fasta path) instead of
+            # a low-level pysam traceback. Without this, calling
+            # oracle.predict(('chrZZ', ...)) crashes deep inside the
+            # oracle's one-hot encoder with KeyError: 'H' (or similar),
+            # which tells the user nothing about what went wrong.
+            try:
+                chrom_length = fasta.get_reference_length(self.chrom)
+            except KeyError:
+                raise IntervalException(
+                    f"Chromosome {self.chrom!r} not found in {self.fasta}. "
+                    f"Check that the chromosome name matches the reference "
+                    f"(hg38 uses 'chr1'..'chr22', 'chrX', 'chrY', 'chrM')."
+                )
         if how == 'left':
             extend_left = extension_needed
         elif how == 'right':

--- a/scripts/build_backgrounds_borzoi.py
+++ b/scripts/build_backgrounds_borzoi.py
@@ -1,7 +1,7 @@
 """Build per-track background distributions for Borzoi.
 
 Produces ``borzoi_pertrack.npz`` with three CDF matrices (effect, summary,
-perbin) per track for all 7,612 Borzoi tracks: CAGE, RNA, DNASE, ATAC,
+perbin) per track for all 7,611 Borzoi tracks: CAGE, RNA, DNASE, ATAC,
 CHIP-TF, CHIP-Histone.
 
 RNA-seq tracks use **exon-precise sampling**: only bins overlapping

--- a/tests/test_prediction_methods.py
+++ b/tests/test_prediction_methods.py
@@ -251,6 +251,40 @@ class TestPredictionMethods:
 
         shutil.rmtree(tmp)
 
+    def test_bad_chromosome_gives_actionable_error(self):
+        """A chromosome not in the reference FASTA must fail with a
+        message that names the bad chrom and the FASTA path — not a
+        low-level pysam.KeyError or a downstream one-hot-encoder
+        KeyError('H').
+
+        Regression for v20 §14.4 finding:
+            oracle.predict(('chrZZ', 100, 300), [...]) used to crash
+            deep in LegNet's transforms with KeyError: 'H'.
+
+        MockOracle._predict shortcircuits the input to random data so
+        we exercise the chokepoint (GenomeRef.slop → pysam) directly
+        plus the predict_variant_effect path which does go through
+        real region_interval[...] indexing.
+        """
+        from chorus.core.interval import GenomeRef, IntervalException
+        from chorus.core.exceptions import InvalidRegionError
+
+        # Path A: GenomeRef.slop — the actual crash site before the fix
+        gr = GenomeRef(chrom="chrZZ", start=100, end=300,
+                       fasta=str(self.fasta_path))
+        with pytest.raises(IntervalException, match="Chromosome 'chrZZ' not found"):
+            gr.slop(extension_needed=1000, how="both")
+
+        # Path B: predict_variant_effect(string) — goes through
+        # extract_sequence → raises InvalidRegionError
+        with pytest.raises(InvalidRegionError, match="[Cc]hromosome.*chrZZ.*not found"):
+            self.oracle.predict_variant_effect(
+                genomic_region="chrZZ:100-300",
+                variant_position="chrZZ:150",
+                alleles=["A", "C"],
+                assay_ids=["DNase:K562"],
+            )
+
     def test_error_handling_model_not_loaded(self):
         """Test error when model not loaded."""
         unloaded_oracle = MockOracle(reference_fasta=str(self.fasta_path))


### PR DESCRIPTION
## Problem

The v20 Linux/CUDA audit ran LegNet against genomics edge cases and surfaced:

```python
oracle.predict(('chrZZ', 100, 300), [...])
# → KeyError: 'H'
```

A chromosome not in the reference FASTA crashed deep inside the oracle's one-hot encoder with a message that told the user nothing. pysam's internal `KeyError(chrom)` was propagating past `GenomeRef.slop()` all the way to the PyTorch transform.

## Fix

Catch `KeyError` in `GenomeRef.slop()` and re-raise as `IntervalException` with an actionable message (`chorus/core/interval.py:51-62`). After the fix:

```
IntervalException: Chromosome 'chrZZ' not found in <path>/hg38.fa.
Check that the chromosome name matches the reference (hg38 uses
'chr1'..'chr22', 'chrX', 'chrY', 'chrM').
```

**Single-chokepoint fix** in `GenomeRef.slop`. Every wide-window prediction path (Enformer, Borzoi, ChromBPNet, Sei, LegNet, AlphaGenome) runs through `slop()` to size the input interval, so one catch covers them all.

`predict_variant_effect` on the same bad chrom was already covered by `extract_sequence`'s explicit check — verified still works.

## Regression test

`tests/test_prediction_methods.py::test_bad_chromosome_gives_actionable_error` exercises both paths:
- `GenomeRef.slop` directly (the old crash site)
- `predict_variant_effect` (already-covered path, verified parity)

## Also lands

`scripts/build_backgrounds_borzoi.py:4` — docstring said **"7,612 Borzoi tracks"**; real count is **7,611**. Last `7,612` in live code. Matches v17's fix to `scripts/README.md`. Originally in PR #35 which was closed as superseded by the other agent's v19/v20 work.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_smoke_predict.py -q` → **335 passed / 1 skipped** (9m 16s; +1 new test)
- [x] Manual reproducer: `oracle.predict(('chrZZ', ...))` now raises `IntervalException` with actionable text
- [x] Manual reproducer: `oracle.predict_variant_effect('chrZZ:100-300', ...)` still raises `InvalidRegionError` with named chrom
- [x] `grep -rn '7,612' scripts/ chorus/ --include='*.py' --include='*.md'` → empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)