### PR TITLE
v26 usability: fix P0 (invalid track) + 4 P1s (CLI noise, bare exceptions, MCP debug)

### DIFF
--- a/chorus/core/environment/manager.py
+++ b/chorus/core/environment/manager.py
@@ -51,18 +51,18 @@ class EnvironmentManager:
         # Check MAMBA_EXE environment variable
         mamba_exe = os.environ.get('MAMBA_EXE')
         if mamba_exe and os.path.exists(mamba_exe):
-            logger.info(f"Found mamba via MAMBA_EXE: {mamba_exe}")
+            logger.debug(f"Found mamba via MAMBA_EXE: {mamba_exe}")
             return mamba_exe
 
         # First check CONDA_EXE environment variable (set by conda when activated)
         conda_exe = os.environ.get('CONDA_EXE')
         if conda_exe and os.path.exists(conda_exe):
-            logger.info(f"Found conda via CONDA_EXE: {conda_exe}")
+            logger.debug(f"Found conda via CONDA_EXE: {conda_exe}")
             # Check if mamba exists in the same directory
             conda_dir = os.path.dirname(conda_exe)
             mamba_exe = os.path.join(conda_dir, 'mamba')
             if os.path.exists(mamba_exe):
-                logger.info(f"Found mamba at: {mamba_exe}")
+                logger.debug(f"Found mamba at: {mamba_exe}")
                 return mamba_exe
             return conda_exe
         
@@ -233,7 +233,13 @@ class EnvironmentManager:
         env_file = self.get_environment_file(oracle)
 
         if not env_file.exists():
-            logger.error(f"Environment file not found: {env_file}")
+            # Name the valid oracles on typos so users don't have to grep
+            # the README or guess. v26 P1 #1.
+            available = sorted(self.list_available_oracles())
+            logger.error(
+                f"No environment file for oracle {oracle!r}. Expected "
+                f"{env_file}. Valid oracle names: {available}"
+            )
             return False
 
         # Check if environment already exists

--- a/chorus/core/interval.py
+++ b/chorus/core/interval.py
@@ -667,10 +667,15 @@ class Interval:
                 c = CigarInsertion(seq=query[querypos:querypos+ilength(l)])
             elif g == CigarDeletion.cigar_symbol:
                 c = CigarDeletion(length=ilength(l))
-            elif g ==  CigarNotEqual.cigar_symbol: 
+            elif g ==  CigarNotEqual.cigar_symbol:
                 c = CigarNotEqual(seq=query[querypos:querypos+ilength(l)])
             else:
-                raise Exception('')
+                # Was a bare Exception('') — meaningless if a user ever
+                # hit it. Known CIGAR symbols are ``= M I D X``; anything
+                # else is a parser error. v26 P1 #13.
+                raise IntervalException(
+                    f"Unknown CIGAR symbol {g!r} (expected one of '=MIDX')"
+                )
             if c.consumes_query:
                 querypos += len(c)
             cigar_groups.append(c)

--- a/chorus/core/platform.py
+++ b/chorus/core/platform.py
@@ -63,7 +63,10 @@ def detect_platform() -> PlatformInfo:
         except (FileNotFoundError, subprocess.TimeoutExpired):
             info.has_cuda = False
 
-    logger.info(
+    # Debug-level so it doesn't lead every CLI invocation (v26 P1 #4).
+    # The detected platform is a diagnostic, not something a first-time
+    # user needs on every `chorus --help` / `chorus list`.
+    logger.debug(
         f"Detected platform: {info.system} {info.machine} "
         f"(key={info.key}, cuda={info.has_cuda})"
     )

--- a/chorus/mcp/server.py
+++ b/chorus/mcp/server.py
@@ -128,8 +128,14 @@ def _safe_tool(fn):
 
     Wraps the function body only; does not interfere with FastMCP's
     registration (apply *inside* ``@mcp.tool()``).
+
+    Set ``CHORUS_MCP_DEBUG=1`` to include ``"traceback": ...`` in the
+    returned dict — useful when debugging a tool call through an MCP
+    client that only prints the JSON reply (v26 P1 #18).
     """
     import functools
+    import os
+    import traceback as _traceback
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
@@ -137,11 +143,14 @@ def _safe_tool(fn):
             return fn(*args, **kwargs)
         except Exception as exc:
             logger.exception("MCP tool %s failed", fn.__name__)
-            return {
+            payload = {
                 "error": str(exc) or type(exc).__name__,
                 "error_type": type(exc).__name__,
                 "tool": fn.__name__,
             }
+            if os.environ.get("CHORUS_MCP_DEBUG", "").lower() in ("1", "true", "yes"):
+                payload["traceback"] = _traceback.format_exc()
+            return payload
 
     return wrapper
 

--- a/chorus/oracles/borzoi.py
+++ b/chorus/oracles/borzoi.py
@@ -4,7 +4,7 @@ from ..core.base import OracleBase
 from ..core.result import OraclePrediction, OraclePredictionTrack
 from ..core.track import Track
 from ..core.interval import Interval, GenomeRef, Sequence
-from ..core.exceptions import ModelNotLoadedError
+from ..core.exceptions import ModelNotLoadedError, InvalidAssayError
 
 from typing import List, Tuple, Union, Optional, Dict, Any
 import os
@@ -297,8 +297,16 @@ class BorzoiOracle(OracleBase):
                 if idx is not None:
                     indices.append(idx)
                 else:
-                    logger.warning(f"Identifier '{assay_id}' not found in metadata")
-                    indices.append(0)
+                    # Raise rather than silently use track 0 — a fallback
+                    # that returned predictions for an arbitrary other
+                    # track corrupted user output without any recovery
+                    # path (v26 P0 finding).
+                    raise InvalidAssayError(
+                        f"Borzoi track identifier '{assay_id}' not found "
+                        f"in metadata. Use oracle.get_track_info() to list "
+                        f"valid identifiers, or oracle.get_track_info(pattern) "
+                        f"to search (e.g. 'DNASE:K562')."
+                    )
             else:
                 # Search by description
                 matches = metadata.get_tracks_by_description(assay_id)
@@ -309,8 +317,11 @@ class BorzoiOracle(OracleBase):
                         logger.info(f"Using first match: {matches[0][1]} (index {matches[0][0]})")
                     indices.append(matches[0][0])
                 else:
-                    logger.warning(f"No tracks found for '{assay_id}'")
-                    indices.append(0)
+                    raise InvalidAssayError(
+                        f"No Borzoi tracks matched description '{assay_id}'. "
+                        f"Use oracle.get_track_info() to discover valid tracks "
+                        f"or oracle.get_track_info(pattern) to search."
+                    )
         
         return indices
     

--- a/chorus/oracles/borzoi_source/templates/predict_template.py
+++ b/chorus/oracles/borzoi_source/templates/predict_template.py
@@ -32,7 +32,14 @@ pred = perform_prediction(flashzoi, args['sequence'], args['length'], device)
 meta = get_metadata()
 track_indices = meta.id2index(args['assay_ids'])
 if any(map(lambda x: x is None, track_indices)):
-    raise Exception(f"Some assay IDs not found in metadata: {args['assay_ids']}")
+    missing = [a for a, i in zip(args['assay_ids'], track_indices) if i is None]
+    # Use ValueError (not bare Exception) so the env-runner surfaces a
+    # recognisable error type. v26 P1.
+    raise ValueError(
+        f"Borzoi track identifier(s) not found in metadata: {missing}. "
+        f"Use oracle.get_track_info() to list valid identifiers, or "
+        f"oracle.get_track_info(pattern) to search (e.g. 'DNASE:K562')."
+    )
 # Extract predictions for selected tracks
 selected_predictions = pred[:, track_indices]
 result = selected_predictions.tolist()

--- a/chorus/oracles/enformer.py
+++ b/chorus/oracles/enformer.py
@@ -12,7 +12,7 @@ from ..core.base import OracleBase
 from ..core.result import OraclePrediction, OraclePredictionTrack
 from ..core.track import Track
 from ..core.interval import Interval, GenomeRef, Sequence 
-from ..core.exceptions import ModelNotLoadedError
+from ..core.exceptions import ModelNotLoadedError, InvalidAssayError
 
 logger = logging.getLogger(__name__)
 
@@ -343,8 +343,16 @@ class EnformerOracle(OracleBase):
                 if idx is not None:
                     indices.append(idx)
                 else:
-                    logger.warning(f"Identifier '{assay_id}' not found in metadata")
-                    indices.append(0)
+                    # Raise rather than silently use track 0 — a fallback
+                    # that returned predictions for an arbitrary other
+                    # track corrupted user output without any recovery
+                    # path (v26 P0 finding).
+                    raise InvalidAssayError(
+                        f"Enformer track identifier '{assay_id}' not found "
+                        f"in metadata. Use oracle.get_track_info() to list "
+                        f"valid identifiers, or oracle.get_track_info(pattern) "
+                        f"to search (e.g. 'DNASE:K562')."
+                    )
             else:
                 # Search by description
                 matches = metadata.get_tracks_by_description(assay_id)
@@ -355,8 +363,11 @@ class EnformerOracle(OracleBase):
                         logger.info(f"Using first match: {matches[0][1]} (index {matches[0][0]})")
                     indices.append(matches[0][0])
                 else:
-                    logger.warning(f"No tracks found for '{assay_id}'")
-                    indices.append(0)
+                    raise InvalidAssayError(
+                        f"No Enformer tracks matched description '{assay_id}'. "
+                        f"Use oracle.get_track_info() to discover valid tracks "
+                        f"or oracle.get_track_info(pattern) to search."
+                    )
         
         return indices
     

--- a/chorus/oracles/enformer_source/templates/predict_template.py
+++ b/chorus/oracles/enformer_source/templates/predict_template.py
@@ -47,7 +47,14 @@ human_predictions = predictions['human'][0].numpy()
 meta = get_metadata()
 track_indices = meta.id2index(args['assay_ids'])
 if any(map(lambda x: x is None, track_indices)):
-    raise Exception(f"Some assay IDs not found in metadata: {args['assay_ids']}")
+    missing = [a for a, i in zip(args['assay_ids'], track_indices) if i is None]
+    # Use ValueError (not bare Exception) so the env-runner surfaces a
+    # recognisable error type through its subprocess wrapper. v26 P1.
+    raise ValueError(
+        f"Enformer track identifier(s) not found in metadata: {missing}. "
+        f"Use oracle.get_track_info() to list valid identifiers, or "
+        f"oracle.get_track_info(pattern) to search (e.g. 'DNASE:K562')."
+    )
 # Extract predictions for selected tracks
 selected_predictions = human_predictions[:, track_indices]
 result = selected_predictions.tolist()

--- a/tests/test_prediction_methods.py
+++ b/tests/test_prediction_methods.py
@@ -410,6 +410,54 @@ class TestPredictionMethods:
         oracle = MockOracle(reference_fasta=str(self.fasta_path))
         assert oracle.device is None
 
+    def test_unknown_track_id_gives_actionable_error(self):
+        """Invalid assay_id must raise InvalidAssayError with a pointer
+        to list_tracks / get_track_info — not silently substitute track 0
+        (previous behaviour corrupted predictions) or surface a cryptic
+        TypeError('NoneType' is not subscriptable).
+
+        Regression for v26 P0 finding. MockOracle doesn't have a real
+        track catalogue so we exercise the enformer code path directly
+        via a stubbed metadata object.
+        """
+        import sys
+        import types
+        import importlib
+        from chorus.core.exceptions import InvalidAssayError
+
+        # Lazy import so the test file still parses when enformer's deps
+        # aren't installed (e.g. fast suite on a clean macOS box).
+        try:
+            from chorus.oracles import enformer as enformer_mod
+        except ImportError:
+            pytest.skip("enformer module not importable")
+
+        # Fake metadata that misses the lookup.
+        fake_meta = types.SimpleNamespace(
+            get_track_by_identifier=lambda x: None,
+            get_tracks_by_description=lambda x: [],
+        )
+        # Minimal EnformerOracle stub so we can drive _get_assay_indices
+        class Stub:
+            pass
+        stub = Stub()
+        # _get_assay_indices imports get_metadata lazily — patch the
+        # source module.
+        from chorus.oracles.enformer_source import enformer_metadata as meta_mod
+        orig_get_metadata = meta_mod.get_metadata
+        meta_mod.get_metadata = lambda: fake_meta
+        try:
+            with pytest.raises(InvalidAssayError, match="get_track_info"):
+                enformer_mod.EnformerOracle._get_assay_indices(
+                    stub, ["ENCFF999BADID"]
+                )
+            with pytest.raises(InvalidAssayError, match="get_track_info"):
+                enformer_mod.EnformerOracle._get_assay_indices(
+                    stub, ["totally made up track name"]
+                )
+        finally:
+            meta_mod.get_metadata = orig_get_metadata
+
     def test_error_handling_model_not_loaded(self):
         """Test error when model not loaded."""
         unloaded_oracle = MockOracle(reference_fasta=str(self.fasta_path))


### PR DESCRIPTION
## Summary

Picks up the actionable items from [v26 usability audit](audits/2026-04-23_v26_usability_audit/report.md). One code-correctness bug, four UX polish fixes.

## P0 #9 — invalid track ID silently returned predictions for track 0

Both `chorus/oracles/enformer.py:346` and `chorus/oracles/borzoi.py:300` logged a warning and **appended index 0 as a fallback** when `get_track_by_identifier()` returned `None`. So:

```python
oracle.predict(('chr1', 0, 100_000), ['ENCFF999BADID'])
# → warning "Identifier 'ENCFF999BADID' not found in metadata"
# → silently returns predictions for track 0 (an arbitrary other track)
```

User output corrupted with no recovery path.

**Fix**: raise `InvalidAssayError` naming the missing ID and pointing at `oracle.get_track_info()`. Also upgraded the env-runner subprocess templates (`enformer_source/templates/predict_template.py`, `borzoi_source/…/predict_template.py`) from bare `raise Exception` to a descriptive `ValueError` (v26 P1 #12 also).

Regression test: `tests/test_prediction_methods.py::test_unknown_track_id_gives_actionable_error`. Covers both the ENCFF-ID and description-search branches with a stubbed metadata object.

## P1 #4 — leading INFO noise on every CLI invocation

Before:
```
$ chorus list
2026-04-23 20:21:55,540 - chorus.core.environment.manager - INFO - Found mamba via MAMBA_EXE: /Users/…/miniforge3/bin/mamba
2026-04-23 20:21:55,540 - chorus.core.platform - INFO - Detected platform: Darwin arm64 (key=macos_arm64, cuda=False)
Available oracle environments:
```

After:
```
$ chorus list
Available oracle environments:
```

Demoted both to `logger.debug` in `core/environment/manager.py` (3 lines) and `core/platform.py` (1 line). Diagnostic, not user-facing.

## P1 #1 — `chorus setup --oracle fakeoracle` lists valid names

Before: `Environment file not found: environments/chorus-fakeoracle.yml`. No hint of valid names.

After: `No environment file for oracle 'fakeoracle'. Expected …. Valid oracle names: ['alphagenome','borzoi','chrombpnet','enformer','legnet','sei']`.

## P1 #13 — bare `raise Exception('')` in interval.py

CIGAR parser fallback raised an empty Exception. Replaced with `IntervalException` naming the bad symbol and valid set (`'=MIDX'`).

## P1 #18 — MCP `_safe_tool` hides traceback

The decorator returns `{"error", "error_type", "tool"}` dicts on failure — MCP clients can't see which line raised.

**Fix**: opt-in `CHORUS_MCP_DEBUG=1` env var includes `"traceback"` in the error payload. Default behaviour unchanged.

## Not addressed here (separate PRs)

- **P1 #10** (TF/absl startup noise): needs `TF_CPP_MIN_LOG_LEVEL=3` in env activation scripts — invasive.
- **P1 #11** (silent env-setup swallow): needs a new `EnvironmentNotReadyError` exception + flag-on-later-use.
- **P2** items: polish pass after these land.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_smoke_predict.py -q` → **340 passed / 1 skipped** (+1 new test)
- [x] `chorus --help` + `chorus list` → no leading INFO noise
- [x] `chorus setup --oracle fakeoracle` → lists valid oracle names
- [x] Manual: `oracle.predict(..., ['ENCFF999BADID'])` → `InvalidAssayError` with `get_track_info()` pointer (both `use_environment=True/False` paths)
- [x] `CHORUS_MCP_DEBUG=1 chorus-mcp` preserves existing behaviour; unset behaves identically to main

🤖 Generated with [Claude Code](https://claude.com/claude-code)