### PR TITLE
v26 remaining P1s: templates + interval + MCP debug + P0 regression test

### DIFF
--- a/chorus/core/interval.py
+++ b/chorus/core/interval.py
@@ -667,10 +667,15 @@ class Interval:
                 c = CigarInsertion(seq=query[querypos:querypos+ilength(l)])
             elif g == CigarDeletion.cigar_symbol:
                 c = CigarDeletion(length=ilength(l))
-            elif g ==  CigarNotEqual.cigar_symbol: 
+            elif g ==  CigarNotEqual.cigar_symbol:
                 c = CigarNotEqual(seq=query[querypos:querypos+ilength(l)])
             else:
-                raise Exception('')
+                # Was a bare Exception('') — meaningless if a user ever
+                # hit it. Known CIGAR symbols are ``= M I D X``; anything
+                # else is a parser error. v26 P1 #13.
+                raise IntervalException(
+                    f"Unknown CIGAR symbol {g!r} (expected one of '=MIDX')"
+                )
             if c.consumes_query:
                 querypos += len(c)
             cigar_groups.append(c)

--- a/chorus/mcp/server.py
+++ b/chorus/mcp/server.py
@@ -128,8 +128,14 @@ def _safe_tool(fn):
 
     Wraps the function body only; does not interfere with FastMCP's
     registration (apply *inside* ``@mcp.tool()``).
+
+    Set ``CHORUS_MCP_DEBUG=1`` to include ``"traceback": ...`` in the
+    returned dict — useful when debugging a tool call through an MCP
+    client that only prints the JSON reply (v26 P1 #18).
     """
     import functools
+    import os
+    import traceback as _traceback
 
     @functools.wraps(fn)
     def wrapper(*args, **kwargs):
@@ -137,11 +143,14 @@ def _safe_tool(fn):
             return fn(*args, **kwargs)
         except Exception as exc:
             logger.exception("MCP tool %s failed", fn.__name__)
-            return {
+            payload = {
                 "error": str(exc) or type(exc).__name__,
                 "error_type": type(exc).__name__,
                 "tool": fn.__name__,
             }
+            if os.environ.get("CHORUS_MCP_DEBUG", "").lower() in ("1", "true", "yes"):
+                payload["traceback"] = _traceback.format_exc()
+            return payload
 
     return wrapper
 

--- a/chorus/oracles/borzoi_source/templates/predict_template.py
+++ b/chorus/oracles/borzoi_source/templates/predict_template.py
@@ -32,7 +32,14 @@ pred = perform_prediction(flashzoi, args['sequence'], args['length'], device)
 meta = get_metadata()
 track_indices = meta.id2index(args['assay_ids'])
 if any(map(lambda x: x is None, track_indices)):
-    raise Exception(f"Some assay IDs not found in metadata: {args['assay_ids']}")
+    missing = [a for a, i in zip(args['assay_ids'], track_indices) if i is None]
+    # Use ValueError (not bare Exception) so the env-runner surfaces a
+    # recognisable error type. v26 P1 #12.
+    raise ValueError(
+        f"Borzoi track identifier(s) not found in metadata: {missing}. "
+        f"Use oracle.get_track_info() to list valid identifiers, or "
+        f"oracle.get_track_info(pattern) to search (e.g. 'DNASE:K562')."
+    )
 # Extract predictions for selected tracks
 selected_predictions = pred[:, track_indices]
 result = selected_predictions.tolist()

--- a/chorus/oracles/enformer_source/templates/predict_template.py
+++ b/chorus/oracles/enformer_source/templates/predict_template.py
@@ -47,7 +47,14 @@ human_predictions = predictions['human'][0].numpy()
 meta = get_metadata()
 track_indices = meta.id2index(args['assay_ids'])
 if any(map(lambda x: x is None, track_indices)):
-    raise Exception(f"Some assay IDs not found in metadata: {args['assay_ids']}")
+    missing = [a for a, i in zip(args['assay_ids'], track_indices) if i is None]
+    # Use ValueError (not bare Exception) so the env-runner surfaces a
+    # recognisable error type through its subprocess wrapper. v26 P1 #12.
+    raise ValueError(
+        f"Enformer track identifier(s) not found in metadata: {missing}. "
+        f"Use oracle.get_track_info() to list valid identifiers, or "
+        f"oracle.get_track_info(pattern) to search (e.g. 'DNASE:K562')."
+    )
 # Extract predictions for selected tracks
 selected_predictions = human_predictions[:, track_indices]
 result = selected_predictions.tolist()

--- a/tests/test_prediction_methods.py
+++ b/tests/test_prediction_methods.py
@@ -410,6 +410,52 @@ class TestPredictionMethods:
         oracle = MockOracle(reference_fasta=str(self.fasta_path))
         assert oracle.device is None
 
+    def test_unknown_track_id_gives_actionable_error(self):
+        """Invalid assay_id must raise InvalidAssayError with a pointer
+        to list_tracks / get_track_info — not silently substitute track 0
+        (previous behaviour corrupted predictions) or surface a cryptic
+        TypeError('NoneType' is not subscriptable).
+
+        Regression for v26 P0 finding (fix in 96fc28d). Exercises the
+        Enformer direct-load code path via a stubbed metadata object.
+        """
+        import types
+        from chorus.core.exceptions import InvalidAssayError
+
+        try:
+            from chorus.oracles import enformer as enformer_mod
+        except ImportError:
+            pytest.skip("enformer module not importable")
+
+        # Fake metadata that misses every lookup.
+        fake_meta = types.SimpleNamespace(
+            get_track_by_identifier=lambda x: None,
+            get_tracks_by_description=lambda x: [],
+        )
+        stub = type("Stub", (), {})()
+
+        from chorus.oracles.enformer_source import enformer_metadata as meta_mod
+        orig = meta_mod.get_metadata
+        meta_mod.get_metadata = lambda: fake_meta
+        try:
+            # _validate_assay_ids is the user-facing gate called by
+            # OracleBase.predict() before _get_assay_indices. Both bad
+            # ENCFF IDs and bad descriptions must raise before reaching
+            # the model.
+            with pytest.raises(InvalidAssayError, match="(list_tracks|search_tracks)"):
+                enformer_mod.EnformerOracle._validate_assay_ids(
+                    stub, ["ENCFF999BADID"]
+                )
+            with pytest.raises(InvalidAssayError, match="(list_tracks|search_tracks)"):
+                enformer_mod.EnformerOracle._validate_assay_ids(
+                    stub, ["totally made up track name"]
+                )
+            # Empty input must not raise.
+            enformer_mod.EnformerOracle._validate_assay_ids(stub, None)
+            enformer_mod.EnformerOracle._validate_assay_ids(stub, [])
+        finally:
+            meta_mod.get_metadata = orig
+
     def test_error_handling_model_not_loaded(self):
         """Test error when model not loaded."""
         unloaded_oracle = MockOracle(reference_fasta=str(self.fasta_path))


### PR DESCRIPTION
## Summary

Closes the 4 remaining v26 items (3 P1s + 1 regression test) that didn't land in the parallel `96fc28d` commit. That commit picked up the track-ID `_validate_assay_ids` override + INFO→DEBUG demotion — great. These 5 files are the rest.

**Answer to "so all good?"**: not quite — these 4 remaining items are real and worth one more small PR.

## P1 #12 — subprocess templates raised bare `Exception`

Both `predict_template.py` files had `raise Exception(f"Some assay IDs not found in metadata: {args['assay_ids']}")`. The env-runner wraps subprocess failures in `RuntimeError`, so users saw a generic traceback instead of a recognisable type. Now raises `ValueError` with:

- A specific list of missing IDs (vs dumping the whole `assay_ids` arg)
- A `get_track_info()` pointer consistent with the direct-load path

## P1 #13 — `chorus/core/interval.py` bare `Exception('')`

CIGAR parser fallback at line 673 raised an empty `Exception('')` — if a user ever hit it they'd get no information. Replaced with `IntervalException` naming the bad CIGAR symbol and the valid set `'=MIDX'`.

## P1 #18 — MCP `_safe_tool` hides traceback

The decorator returns `{"error", "error_type", "tool"}` dicts on failure. MCP clients debugging a failing tool can't see which line raised. Opt-in via `CHORUS_MCP_DEBUG=1` env var now includes a `"traceback"` field in the error payload. Default behaviour unchanged.

## P0 regression test

`96fc28d` added `EnformerOracle._validate_assay_ids` but shipped no regression test. Added `test_unknown_track_id_gives_actionable_error` that exercises the override with a stubbed metadata (no TF needed in the base `chorus` env). Covers:

- Unknown `ENCFF…` ID → `InvalidAssayError` naming `list_tracks` / `search_tracks`
- Unknown description → same
- `None`/`[]` input → no-op, doesn't raise

## Test plan
- [x] `pytest tests/ --ignore=tests/test_smoke_predict.py -q` → **340 passed / 1 skipped** (+1 from 339, the new regression test)
- [x] Manual: `oracle.predict(..., ['ENCFF999BADID'])` via env-runner → error contains `get_track_info()` + list of missing IDs
- [x] `grep "raise Exception('')" chorus/` → 0 matches (was 1)
- [x] `grep "raise Exception(f\"Some assay" chorus/` → 0 matches (was 2)
- [x] `CHORUS_MCP_DEBUG=1` includes traceback in MCP error payload; unset omits it

🤖 Generated with [Claude Code](https://claude.com/claude-code)