### PR TITLE
v26 tail cleanup: CLI preflight + ChorusError hierarchy + MCP guard

### DIFF
--- a/chorus/cli/main.py
+++ b/chorus/cli/main.py
@@ -39,6 +39,18 @@ def setup_environments(args):
         from ._setup_all import setup_all_oracles
         return setup_all_oracles(args)
 
+    # Preflight: reject unknown oracle names with the list of valid
+    # ones, instead of the cryptic "Environment file not found" from
+    # create_environment. v26 P1 #1.
+    available = manager.list_available_oracles()
+    if args.oracle not in available:
+        logger.error(
+            f"Unknown oracle: {args.oracle!r}. "
+            f"Valid oracles: {', '.join(sorted(available))} "
+            f"(or 'all' / omit --oracle to set up every oracle)."
+        )
+        return 1
+
     oracles = [args.oracle]
 
     # AlphaGenome is gated; resolve the HF token up front so we don't
@@ -146,11 +158,18 @@ def validate_environments(args):
     manager = EnvironmentManager()
     
     if args.oracle:
+        available = manager.list_available_oracles()
+        if args.oracle not in available:
+            logger.error(
+                f"Unknown oracle: {args.oracle!r}. "
+                f"Valid oracles: {', '.join(sorted(available))}."
+            )
+            return 1
         oracles = [args.oracle]
     else:
-        oracles = [o for o in manager.list_available_oracles() 
+        oracles = [o for o in manager.list_available_oracles()
                   if manager.environment_exists(o)]
-    
+
     if not oracles:
         logger.info("No installed environments to validate.")
         return 0
@@ -206,11 +225,18 @@ def check_health(args):
     runner = EnvironmentRunner(manager)
     
     if args.oracle:
+        available = manager.list_available_oracles()
+        if args.oracle not in available:
+            logger.error(
+                f"Unknown oracle: {args.oracle!r}. "
+                f"Valid oracles: {', '.join(sorted(available))}."
+            )
+            return 1
         oracles = [args.oracle]
     else:
-        oracles = [o for o in manager.list_available_oracles() 
+        oracles = [o for o in manager.list_available_oracles()
                   if manager.environment_exists(o)]
-    
+
     if not oracles:
         logger.info("No installed environments to check.")
         return 0

--- a/chorus/core/exceptions.py
+++ b/chorus/core/exceptions.py
@@ -11,18 +11,31 @@ class ModelNotLoadedError(ChorusError):
     pass
 
 
-class InvalidSequenceError(ChorusError):
-    """Raised when an invalid DNA sequence is provided."""
+class InvalidSequenceError(ChorusError, ValueError):
+    """Raised when an invalid DNA sequence is provided.
+
+    Inherits from ``ValueError`` as well so legacy ``except ValueError``
+    handlers still catch it — v26 P2 #19.
+    """
     pass
 
 
-class InvalidAssayError(ChorusError):
-    """Raised when an invalid assay type is requested."""
+class InvalidAssayError(ChorusError, ValueError):
+    """Raised when an invalid assay type is requested.
+
+    Inherits from ``ValueError`` as well — v26 P2 #19.
+    """
     pass
 
 
-class InvalidRegionError(ChorusError):
-    """Raised when an invalid genomic region is specified."""
+class InvalidRegionError(ChorusError, ValueError):
+    """Raised when an invalid genomic region is specified.
+
+    Inherits from ``ValueError`` as well so the MCP helpers
+    ``_parse_region`` / ``_parse_position`` keep their
+    ``except ValueError`` contract while also being catchable as
+    ``ChorusError`` — v26 P2 #19.
+    """
     pass
 
 

--- a/chorus/mcp/server.py
+++ b/chorus/mcp/server.py
@@ -14,6 +14,7 @@ from typing import Optional
 
 from fastmcp import FastMCP
 
+from chorus.core.exceptions import InvalidRegionError
 from chorus.mcp.state import OracleStateManager
 from chorus.mcp.serializers import (
     serialize_prediction,
@@ -91,27 +92,34 @@ _POSITION_RE = re.compile(r'^(chr[\w]+):(\d+)$')
 
 
 def _parse_region(region: str) -> tuple[str, int, int]:
-    """Parse 'chrN:start-end' into (chrom, start, end) with validation."""
+    """Parse 'chrN:start-end' into (chrom, start, end) with validation.
+
+    Raises ``InvalidRegionError`` (a ``ChorusError`` subclass) so callers
+    can handle all Chorus-family errors uniformly. v26 P2 #19.
+    """
     m = _REGION_RE.match(region)
     if not m:
-        raise ValueError(
-            f"Invalid region format: '{region}'. "
+        raise InvalidRegionError(
+            f"Invalid region format: {region!r}. "
             f"Expected 'chrN:start-end' (e.g. 'chr1:1000000-1393216')."
         )
     chrom, start, end = m.group(1), int(m.group(2)), int(m.group(3))
     if start >= end:
-        raise ValueError(
-            f"Invalid region: start ({start}) must be less than end ({end})."
+        raise InvalidRegionError(
+            f"Invalid region {region!r}: start ({start}) must be less than end ({end})."
         )
     return chrom, start, end
 
 
 def _parse_position(position: str) -> tuple[str, int]:
-    """Parse 'chrN:pos' into (chrom, pos) with validation."""
+    """Parse 'chrN:pos' into (chrom, pos) with validation.
+
+    Raises ``InvalidRegionError`` (a ``ChorusError`` subclass). v26 P2 #19.
+    """
     m = _POSITION_RE.match(position)
     if not m:
-        raise ValueError(
-            f"Invalid position format: '{position}'. "
+        raise InvalidRegionError(
+            f"Invalid position format: {position!r}. "
             f"Expected 'chrN:position' (e.g. 'chr1:1050000')."
         )
     return m.group(1), int(m.group(2))
@@ -238,6 +246,20 @@ def list_tracks(oracle_name: str, query: Optional[str] = None) -> dict:
         query: Optional search string to filter tracks (e.g. "K562", "DNASE"). Use the returned 'identifier' field as the assay_id for predictions.
     """
     oracle_name = oracle_name.lower()
+
+    # Validate oracle name up front — v26 P2 #20: previous behaviour
+    # dropped through to the fall-through error dict, which was easy to
+    # miss. Surface the mismatch explicitly with the valid names.
+    if oracle_name not in ORACLE_SPECS:
+        valid = ", ".join(sorted(ORACLE_SPECS.keys()))
+        logger.warning(
+            "list_tracks called with unknown oracle %r (valid: %s)",
+            oracle_name, valid,
+        )
+        return {
+            "error": f"Unknown oracle: {oracle_name!r}. Valid names: {valid}",
+            "oracle": oracle_name,
+        }
 
     # Try Borzoi metadata (richest search)
     if oracle_name == "borzoi":


### PR DESCRIPTION
## Summary

Closes the last v26 backlog items so v26 is fully landed on main.

- **P1 #1 / #2** (`cli/main.py`): `chorus setup --oracle <bad>`, `chorus health --oracle <bad>`, and `chorus validate --oracle <bad>` now reject unknown names up front with the valid list. Exit codes were already non-zero; this makes the message actionable. (`chorus genome download <bad>` already did this.)
- **P2 #19** (`core/exceptions.py`, `mcp/server.py`): `_parse_region` / `_parse_position` raise `InvalidRegionError` (a `ChorusError` subclass) instead of bare `ValueError`. `InvalidSequenceError`, `InvalidAssayError`, `InvalidRegionError` now multiply inherit from `ChorusError` + `ValueError` so legacy `except ValueError` handlers still catch them.
- **P2 #20** (`mcp/server.py`): `list_tracks(oracle_name)` preflight-validates the oracle name against `ORACLE_SPECS` and logs + returns an explicit error dict naming the valid oracles, rather than falling through.

Scope: 3 files, +79/−18.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_smoke_predict.py -q` → 340 passed, 1 skipped
- [x] `chorus setup --oracle fakeoracle` → exit 1, "Valid oracles: alphagenome, borzoi, chrombpnet, enformer, legnet, sei"
- [x] `chorus health --oracle fakeoracle` → exit 1, same valid-list message

## Remaining v26

After this: **only P2 #5 (inconsistent error style sweep)** remains — deferred because it's a diffuse stylistic cleanup, not a correctness issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)