### PR TITLE
v26 P2 #5: error-style consistency sweep

### DIFF
--- a/chorus/cli/_setup_prefetch.py
+++ b/chorus/cli/_setup_prefetch.py
@@ -92,17 +92,17 @@ def prefetch_weights(oracle: str, runner, timeout: Optional[int] = None) -> Tupl
     result = runner.run_script_in_environment(oracle, script, timeout=timeout)
 
     if result.returncode != 0:
-        return (False, f"subprocess exited {result.returncode}: {result.stderr[-500:]}")
+        return (False, f"Subprocess exited {result.returncode}: {result.stderr[-500:]}.")
 
     try:
         payload = json.loads(result.stdout.splitlines()[-1])
     except (json.JSONDecodeError, IndexError):
-        return (False, f"unparseable output: {result.stdout[-500:]}")
+        return (False, f"Unparseable output: {result.stdout[-500:]}.")
 
     if payload.get("success"):
         logger.info("✓ %s weights ready", oracle)
         return (True, None)
-    return (False, payload.get("error", "unknown load failure"))
+    return (False, f"{payload.get('error', 'unknown load failure')}.")
 
 
 def prefetch_backgrounds(oracle: str) -> Tuple[bool, Optional[str]]:
@@ -110,12 +110,12 @@ def prefetch_backgrounds(oracle: str) -> Tuple[bool, Optional[str]]:
     try:
         from ..analysis.normalization import download_backgrounds
     except Exception as exc:
-        return (False, f"import failed: {exc}")
+        return (False, f"Import failed: {exc}.")
 
     try:
         n = download_backgrounds(oracle)
     except Exception as exc:
-        return (False, f"download failed: {exc}")
+        return (False, f"Download failed: {exc}.")
 
     if n == 0:
         logger.info("Backgrounds for %s already cached (or unavailable)", oracle)
@@ -129,7 +129,7 @@ def prefetch_genome(genome_id: str = "hg38") -> Tuple[bool, Optional[str]]:
     try:
         from ..utils.genome import GenomeManager
     except Exception as exc:
-        return (False, f"import failed: {exc}")
+        return (False, f"Import failed: {exc}.")
 
     mgr = GenomeManager()
     if mgr.is_genome_downloaded(genome_id):
@@ -140,10 +140,10 @@ def prefetch_genome(genome_id: str = "hg38") -> Tuple[bool, Optional[str]]:
     try:
         ok = mgr.download_genome(genome_id)
     except Exception as exc:
-        return (False, f"download failed: {exc}")
+        return (False, f"Download failed: {exc}.")
 
     if not ok:
-        return (False, f"{genome_id} download returned False")
+        return (False, f"{genome_id} download returned False. Retry with `chorus genome download {genome_id}`.")
     logger.info("✓ %s ready", genome_id)
     return (True, None)
 

--- a/chorus/cli/_tokens.py
+++ b/chorus/cli/_tokens.py
@@ -98,7 +98,10 @@ def resolve_hf_token(
         if user:
             logger.info("✓ HuggingFace auth ok (user: %s, via --hf-token)", user)
             return True
-        logger.error("HuggingFace rejected the token passed via --hf-token")
+        logger.error(
+            "HuggingFace rejected the token passed via --hf-token. "
+            "Verify it at https://huggingface.co/settings/tokens and retry."
+        )
         _print_hf_setup_instructions("token was rejected")
         return False
 
@@ -109,7 +112,10 @@ def resolve_hf_token(
         if user:
             logger.info("✓ HuggingFace auth ok (user: %s, via env)", user)
             return True
-        logger.error("HuggingFace rejected the token from HF_TOKEN / HUGGING_FACE_HUB_TOKEN")
+        logger.error(
+            "HuggingFace rejected the token from HF_TOKEN / HUGGING_FACE_HUB_TOKEN. "
+            "Verify it at https://huggingface.co/settings/tokens and retry."
+        )
         _print_hf_setup_instructions("env-var token was rejected")
         return False
 
@@ -139,7 +145,10 @@ def resolve_hf_token(
     if user:
         logger.info("✓ HuggingFace auth ok (user: %s, saved via huggingface-cli)", user)
         return True
-    logger.error("HuggingFace rejected the provided token — check it and retry")
+    logger.error(
+        "HuggingFace rejected the provided token. "
+        "Verify it at https://huggingface.co/settings/tokens and retry."
+    )
     _print_hf_setup_instructions("token was rejected")
     return False
 

--- a/chorus/cli/main.py
+++ b/chorus/cli/main.py
@@ -83,7 +83,10 @@ def setup_environments(args):
                 stale.unlink()
 
         if not manager.create_environment(oracle, force=args.force):
-            logger.error(f"✗ Failed to build env for {oracle}")
+            logger.error(
+                f"✗ Failed to build env for {oracle}. "
+                f"Re-run with --force to rebuild, or check the mamba/conda output above."
+            )
             continue
         logger.info(f"✓ env for {oracle}")
 
@@ -103,7 +106,7 @@ def setup_environments(args):
             skip_genome=args.no_genome,
         )
         if not ok:
-            logger.error(f"✗ prefetch failed for {oracle}:")
+            logger.error(f"✗ Prefetch failed for {oracle}. Details:")
             for err in errors:
                 logger.error(f"  - {err}")
             continue
@@ -195,11 +198,17 @@ def remove_environments(args):
     manager = EnvironmentManager()
     
     if not args.oracle:
-        logger.error("Please specify an oracle to remove with --oracle")
+        logger.error(
+            "Please specify an oracle to remove with --oracle <name>. "
+            "Run `chorus list` to see installed oracles."
+        )
         return 1
-    
+
     if not manager.environment_exists(args.oracle):
-        logger.error(f"Environment for {args.oracle} does not exist.")
+        logger.error(
+            f"Environment for {args.oracle!r} does not exist. "
+            f"Run `chorus list` to see installed oracles."
+        )
         return 1
     
     # Confirm removal
@@ -303,8 +312,10 @@ def download_genome(args):
     manager = GenomeManager()
     
     if args.genome not in manager.list_available_genomes():
-        logger.error(f"Unknown genome: {args.genome}")
-        logger.info(f"Available genomes: {', '.join(manager.list_available_genomes().keys())}")
+        logger.error(
+            f"Unknown genome: {args.genome!r}. "
+            f"Available genomes: {', '.join(manager.list_available_genomes().keys())}."
+        )
         return 1
     
     if manager.is_genome_downloaded(args.genome) and not args.force:
@@ -314,10 +325,13 @@ def download_genome(args):
     
     logger.info(f"Downloading {args.genome}...")
     if manager.download_genome(args.genome, force=args.force):
-        logger.info(f"Successfully downloaded {args.genome}")
+        logger.info(f"Successfully downloaded {args.genome}.")
         return 0
     else:
-        logger.error(f"Failed to download {args.genome}")
+        logger.error(
+            f"Failed to download {args.genome}. "
+            f"Check your network connection and retry, optionally with --force."
+        )
         return 1
 
 
@@ -344,10 +358,10 @@ def remove_genome(args):
             return 0
     
     if manager.remove_genome(args.genome):
-        logger.info(f"Successfully removed genome {args.genome}")
+        logger.info(f"Successfully removed genome {args.genome}.")
         return 0
     else:
-        logger.error(f"Failed to remove genome {args.genome}")
+        logger.error(f"Failed to remove genome {args.genome}.")
         return 1
 
 

--- a/chorus/oracles/alphagenome.py
+++ b/chorus/oracles/alphagenome.py
@@ -128,9 +128,9 @@ class AlphaGenomeOracle(OracleBase):
                 else:
                     raise ModelNotLoadedError(
                         "AlphaGenome requires HuggingFace authentication. "
-                        "Set the HF_TOKEN environment variable or run 'huggingface-cli login'. "
+                        "Set the HF_TOKEN environment variable or run `huggingface-cli login`. "
                         "You must also accept the model license at "
-                        "https://huggingface.co/google/alphagenome-all-folds"
+                        "https://huggingface.co/google/alphagenome-all-folds."
                     )
 
             if force_cpu:
@@ -157,7 +157,7 @@ class AlphaGenomeOracle(OracleBase):
         except ModelNotLoadedError:
             raise
         except Exception as e:
-            raise ModelNotLoadedError(f"Failed to load AlphaGenome model: {e}")
+            raise ModelNotLoadedError(f"Failed to load AlphaGenome model: {e}.")
 
     def _load_in_environment(self, weights: str) -> None:
         args = {

--- a/chorus/oracles/borzoi.py
+++ b/chorus/oracles/borzoi.py
@@ -131,7 +131,7 @@ class BorzoiOracle(OracleBase):
             self.loaded = True
             logger.info("Borzoi model loaded successfully!")
         except Exception as e:
-            raise ModelNotLoadedError(f"Failed to load Borzoi model: {str(e)}")
+            raise ModelNotLoadedError(f"Failed to load Borzoi model: {e}.")
 
     def _load_in_environment(self, weights: str) -> None:
         args = {
@@ -154,7 +154,10 @@ class BorzoiOracle(OracleBase):
                 self._model_info = model_info
                 logger.info("Borzoi model loaded successfully in environment!")
             else:
-                raise ModelNotLoadedError("Failed to load Borzoi model in environment")
+                raise ModelNotLoadedError(
+                    "Failed to load Borzoi model in the chorus-borzoi environment. "
+                    "Run `chorus health --oracle borzoi` to diagnose."
+                )
 
     
     def _predict(self, seq: str | Tuple[str, int, int] | Interval, assay_ids: List[str] | None = None) -> OraclePrediction:

--- a/chorus/oracles/chrombpnet.py
+++ b/chorus/oracles/chrombpnet.py
@@ -4,7 +4,7 @@ from ..core.base import OracleBase
 from ..core.track import Track
 from ..core.result import OraclePrediction, OraclePredictionTrack
 from ..core.interval import Interval, GenomeRef, Sequence
-from ..core.exceptions import ModelNotLoadedError
+from ..core.exceptions import ModelNotLoadedError, InvalidAssayError
 from ..core.globals import CHORUS_DOWNLOADS_DIR
 from .chrombpnet_source.chrombpnet_globals import CHROMBPNET_MODELS_DICT
 
@@ -277,25 +277,38 @@ class ChromBPNetOracle(OracleBase):
         """Load ChromBPNet model weights."""
 
         if assay is None or cell_type is None:
-            raise ValueError("You must provide both assay and cell-type if weights are None.")
-        
+            raise InvalidAssayError(
+                "You must provide both `assay` and `cell_type` when `weights` is None."
+            )
+
         if not is_custom:
             if assay not in CHROMBPNET_MODELS_DICT:
-                raise ValueError(f"ChromBPNet supports only the following assays: {list(CHROMBPNET_MODELS_DICT.keys())}")
-            
-            if assay != "CHIP":            
-                # Check if the combination is valid
+                raise InvalidAssayError(
+                    f"ChromBPNet supports only the following assays: "
+                    f"{list(CHROMBPNET_MODELS_DICT.keys())}."
+                )
+
+            if assay != "CHIP":
                 if cell_type not in CHROMBPNET_MODELS_DICT[assay]:
-                    raise ValueError(f"ChromBPNet {assay} predictions can only be done on the following cell types: {list(CHROMBPNET_MODELS_DICT[assay].keys())}")
+                    raise InvalidAssayError(
+                        f"ChromBPNet {assay} predictions can only be done on the following "
+                        f"cell types: {list(CHROMBPNET_MODELS_DICT[assay].keys())}."
+                    )
 
                 if fold not in range(5):
-                    raise ValueError(f"ChromBPNet fold must be an integer between 0 and 4, got {fold}")
+                    raise InvalidAssayError(
+                        f"ChromBPNet fold must be an integer between 0 and 4, got {fold}."
+                    )
             else:
                 if TF is None:
-                    raise ValueError(f"You must provide TF for which you want ChIP-seq model.")
+                    raise InvalidAssayError(
+                        "You must provide `TF` when requesting a ChIP-seq ChromBPNet model."
+                    )
         else:
             if weights is None:
-                raise ValueError("You must provide weights if custom flag is set.")
+                raise InvalidAssayError(
+                    "You must provide `weights` when `is_custom=True`."
+                )
             
         # Store assay and celltype
         self.assay = assay
@@ -363,7 +376,10 @@ class ChromBPNetOracle(OracleBase):
                 self._model_info = model_info
                 logger.info("ChromBPNet model loaded successfully in environment!")
             else:
-                raise ModelNotLoadedError("Failed to load ChromBPNet model in environment")
+                raise ModelNotLoadedError(
+                    "Failed to load ChromBPNet model in the chorus-chrombpnet environment. "
+                    "Run `chorus health --oracle chrombpnet` to diagnose."
+                )
     
     def _load_direct(self, weights: str):
         """Load model directly in current environment"""
@@ -416,7 +432,7 @@ class ChromBPNetOracle(OracleBase):
             logger.info("ChromBPNet model loaded successfully!")
 
         except Exception as e:
-            raise ModelNotLoadedError(f"Failed to load ChromBPNet model: {str(e)}")
+            raise ModelNotLoadedError(f"Failed to load ChromBPNet model: {e}.")
     
     def list_assay_types(self) -> List[str]:
         """Return ChromBPNet's assay types."""

--- a/chorus/oracles/enformer.py
+++ b/chorus/oracles/enformer.py
@@ -169,7 +169,7 @@ class EnformerOracle(OracleBase):
             self.loaded = True
             logger.info("Enformer model loaded successfully!")
         except Exception as e:
-            raise ModelNotLoadedError(f"Failed to load Enformer model: {str(e)}")
+            raise ModelNotLoadedError(f"Failed to load Enformer model: {e}.")
 
     def _load_in_environment(self, weights: str) -> None:
         args = {
@@ -192,7 +192,10 @@ class EnformerOracle(OracleBase):
                 self._model_info = model_info
                 logger.info("Enformer model loaded successfully in environment!")
             else:
-                raise ModelNotLoadedError("Failed to load Enformer model in environment")
+                raise ModelNotLoadedError(
+                    "Failed to load Enformer model in the chorus-enformer environment. "
+                    "Run `chorus health --oracle enformer` to diagnose."
+                )
 
     
     def _predict(self, seq: str | Tuple[str, int, int] | Interval, assay_ids: List[str] | None = None) -> OraclePrediction:

--- a/chorus/oracles/legnet.py
+++ b/chorus/oracles/legnet.py
@@ -148,7 +148,10 @@ class LegNetOracle(OracleBase):
                 self._model_info = model_info
                 logger.info("LegNet model loaded successfully in environment!")
             else:
-                raise ModelNotLoadedError("Failed to load LegNet model in environment")
+                raise ModelNotLoadedError(
+                    "Failed to load LegNet model in the chorus-legnet environment. "
+                    "Run `chorus health --oracle legnet` to diagnose."
+                )
     
     def _load_direct(self):
         try:
@@ -173,7 +176,7 @@ class LegNetOracle(OracleBase):
             logger.info("LegNet model loaded successfully!")
 
         except Exception as e:
-            raise ModelNotLoadedError(f"Failed to load LegNet model: {str(e)}")
+            raise ModelNotLoadedError(f"Failed to load LegNet model: {e}.")
     
     def list_assay_types(self) -> List[str]:
         """Return LegNet's assay types."""

--- a/chorus/oracles/sei.py
+++ b/chorus/oracles/sei.py
@@ -184,7 +184,10 @@ class SeiOracle(OracleBase):
                 self._model_info = model_info
                 logger.info("Sei model loaded successfully in environment!")
             else:
-                raise ModelNotLoadedError("Failed to load Sei model in environment")
+                raise ModelNotLoadedError(
+                    "Failed to load Sei model in the chorus-sei environment. "
+                    "Run `chorus health --oracle sei` to diagnose."
+                )
     
     def _load_direct(self):
         try:
@@ -229,7 +232,7 @@ class SeiOracle(OracleBase):
             self.loaded = True
             logger.info("Sei model loaded successfully!")
         except Exception as e:
-            raise ModelNotLoadedError(f"Failed to load Sei model: {str(e)}")
+            raise ModelNotLoadedError(f"Failed to load Sei model: {e}.")
 
     
     def list_assay_types(self) -> List[str]:


### PR DESCRIPTION
## Summary

Closes the final v26 audit item (P2 #5 — inconsistent error style). No behavioural changes; just uniform periods and actionable fix hints across the CLI and oracle surfaces.

### CLI
- `logger.error(...)` messages all end with a period; HF-token rejections point at `https://huggingface.co/settings/tokens`.
- `chorus remove --oracle`, `chorus genome download` errors name the exact follow-up command.
- `_setup_prefetch.py` return-tuple strings capitalised + period-terminated so the `"  - {err}"` render under `chorus setup` reads uniformly.

### Oracles
- `"Failed to load X model in environment"` → names the conda env (`chorus-X`) + points at `chorus health --oracle X`, across Enformer / Borzoi / ChromBPNet / Sei / LegNet.
- `"Failed to load X model: {e}"` now ends with a period; dropped redundant `str(e)`.
- ChromBPNet's 6 `ValueError` calls for bad assay/cell/fold become `InvalidAssayError` (matches Enformer/Borzoi/Sei/AlphaGenome). Dual `ChorusError, ValueError` inheritance keeps `except ValueError` callers working.
- AlphaGenome HF-auth error message ends with a period.

Scope: 9 files, +97/−46.

## Test plan
- [x] `pytest tests/ --ignore=tests/test_smoke_predict.py -q` → 340 passed, 1 skipped
- [ ] `chorus setup --oracle fakeoracle` → clean period-terminated message with valid list
- [ ] `chorus remove --oracle fakeoracle` → "Environment for 'fakeoracle' does not exist. Run \`chorus list\` to see installed oracles."

## v26 status after this

All 16 v26 items closed. No outstanding audit findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)