### PR TITLE
Expand ChromBPNet registry to all 42 ENCODE-published models

### DIFF
--- a/chorus/analysis/discovery.py
+++ b/chorus/analysis/discovery.py
@@ -576,11 +576,14 @@ def discover_variant_effects(
         variant_result = None  # will build from best tracks later
 
         if name == "chrombpnet":
-            from ..oracles.chrombpnet_source.chrombpnet_globals import CHROMBPNET_MODELS_DICT
-            models = []
-            for assay in ("ATAC", "DNASE"):
-                for cell_type in CHROMBPNET_MODELS_DICT.get(assay, {}):
-                    models.append({"assay": assay, "cell_type": cell_type})
+            from ..oracles.chrombpnet_source.chrombpnet_globals import iter_unique_models
+            # Dedupe by ENCFF — the registry has aliases (`"limb"` and
+            # `"limb_E12.5"` point to the same model); without dedup
+            # discover_variant_effects would load the same weights twice.
+            models = [
+                {"assay": assay, "cell_type": cell_type}
+                for assay, cell_type, _encff in iter_unique_models()
+            ]
         elif name == "legnet":
             from ..oracles.legnet_source.legnet_globals import LEGNET_AVAILABLE_CELLTYPES
             models = [{"cell_type": ct} for ct in LEGNET_AVAILABLE_CELLTYPES]

--- a/chorus/oracles/chrombpnet_source/chrombpnet_globals.py
+++ b/chorus/oracles/chrombpnet_source/chrombpnet_globals.py
@@ -1,31 +1,133 @@
+# ENCODE ChromBPNet model registry.
+#
+# Sourced from the ENCODE Portal search:
+#   https://www.encodeproject.org/search/?type=Annotation&annotation_type=ChromBPNet-model
+# Last sync: 2026-04-25 — 42 of 43 published annotations have a model
+# tar (ENCSR498NUZ retina DNase-seq has no model file yet).
+#
+# Schema:
+#   - Top-level key: assay (ATAC / DNASE / CHIP).
+#   - Sub-key: ``cell_type`` string the user passes to
+#     ``load_pretrained_model(assay=..., cell_type=...)``.
+#   - Value: ENCFF accession of the model tar on the ENCODE Portal.
+#
+# Disambiguation: where ENCODE published more than one model for the
+# same biosample (mouse developmental atlas — multiple embryonic
+# stages, sometimes multiple replicates per stage), the registry
+# exposes both:
+#   1. A bare biosample alias (e.g. ``"limb"``) → kept identical to
+#      the v27 chorus default so existing scripts keep working.
+#   2. Stage-suffixed entries (``"limb_E11.5"`` / ``"limb_E12.5"`` /
+#      ``"limb_E14.5"``) → reach the other ENCODE-published variants.
+#
+# Known gaps (v28 audit):
+#   - Per-track CDF backgrounds (``~/.chorus/backgrounds/chrombpnet_pertrack.npz``)
+#     were built against the original 24 (assay, biosample) keys only.
+#     Stage-suffixed variants will predict normally but won't have
+#     percentile-normalised scoring until the CDFs are rebuilt by
+#     ``scripts/build_backgrounds_chrombpnet.py`` on a GPU host.
+#   - CHIP / BPNet models live in ``chrombpnet_JASPAR_metadata.tsv``
+#     (1259 TF×cell_type entries, JASPAR_DeepLearning 2026 release).
+#     They're loaded via the BPNetMetadata path, not this dict.
+
 CHROMBPNET_MODELS_DICT: dict[str, dict[str, str]] = {
-        "ATAC": {
-            "K562": "ENCFF984RAF",
-            "HepG2": "ENCFF137WCM",
-            "GM12878": "ENCFF142IOR",
-            "IMR-90": "ENCFF113GSV",
-            "neural_tube": "ENCFF031NTE",
-            "heart": "ENCFF621FME",
-            "hindbrain": "ENCFF620TIL",
-            "liver": "ENCFF302KPO",
-            "limb": "ENCFF606BNG",
-            "embryonic_facial_prominence": "ENCFF894OSV",
-            "forebrain": "ENCFF501TIK",
-            "midbrain": "ENCFF503GTJ"
-        },
-        "DNASE": {
-            "HepG2": "ENCFF615AKY",
-            "IMR-90": "ENCFF515HBV",
-            "GM12878": "ENCFF673TIN",
-            "K562": "ENCFF574YLK",
-            "forelimb_bud": "ENCFF244FWC",
-            "forebrain": "ENCFF271AKE",
-            "liver": "ENCFF053FQE",
-            "limb": "ENCFF067XGA",
-            "neural_tube": "ENCFF541EGW",
-            "embryonic_facial_prominence": "ENCFF715EMI",
-            "midbrain": "ENCFF431PYL",
-            "hindbrain": "ENCFF186EHP"
-        },
-        "CHIP": {}
-    }
+    "ATAC": {
+        # ── Human cell lines (ENCODE 4) ──
+        "K562": "ENCFF984RAF",                       # ENCSR467RSV
+        "HepG2": "ENCFF137WCM",                      # ENCSR380YGX
+        "GM12878": "ENCFF142IOR",                    # ENCSR389HIH
+        "IMR-90": "ENCFF113GSV",                     # ENCSR978WIX
+
+        # ── Mouse developmental atlas — bare-biosample defaults
+        # (kept identical to chorus v27 values; the corresponding
+        # _E* alias points to the same ENCFF). ──
+        "neural_tube": "ENCFF031NTE",                # ENCSR226MTN E11.5
+        "heart":       "ENCFF621FME",                # ENCSR970BZN E14.5
+        "hindbrain":   "ENCFF620TIL",                # ENCSR638HWZ E11.5
+        "liver":       "ENCFF302KPO",                # ENCSR533ULZ E14.5
+        "limb":        "ENCFF606BNG",                # ENCSR303KKP E12.5
+        "embryonic_facial_prominence": "ENCFF894OSV",  # ENCSR443PIH E11.5
+        "forebrain":   "ENCFF501TIK",                # ENCSR465POI E11.5
+        "midbrain":    "ENCFF503GTJ",                # ENCSR843KLE E11.5
+
+        # ── Stage-suffixed mouse variants (new in v28) ──
+        "limb_E11.5":         "ENCFF236MMP",         # ENCSR495VMZ
+        "limb_E12.5":         "ENCFF606BNG",         # ENCSR303KKP (same as "limb")
+        "limb_E14.5":         "ENCFF905ILM",         # ENCSR281ETP
+        "heart_E11.5":        "ENCFF750NGU",         # ENCSR345GMN
+        "heart_E12.5":        "ENCFF054CFO",         # ENCSR226NMV
+        "heart_E14.5":        "ENCFF621FME",         # ENCSR970BZN (same as "heart")
+        "liver_E11.5":        "ENCFF596GBF",         # ENCSR229OZL
+        "liver_E12.5":        "ENCFF129BPA",         # ENCSR566EUK
+        "liver_E14.5":        "ENCFF302KPO",         # ENCSR533ULZ (same as "liver")
+        "hindbrain_E11.5":    "ENCFF620TIL",         # ENCSR638HWZ (same as "hindbrain")
+        "hindbrain_E14.5":    "ENCFF528XQO",         # ENCSR173UYQ
+        "embryonic_facial_prominence_E11.5": "ENCFF894OSV",  # ENCSR443PIH (same as bare)
+        "embryonic_facial_prominence_E12.5": "ENCFF927BHN",  # ENCSR310TZS
+        "embryonic_facial_prominence_E14.5": "ENCFF817FFY",  # ENCSR574HAS
+        "forebrain_E11.5":    "ENCFF501TIK",         # ENCSR465POI (same as "forebrain")
+        "midbrain_E11.5":     "ENCFF503GTJ",         # ENCSR843KLE (same as "midbrain")
+        "neural_tube_E11.5":  "ENCFF031NTE",         # ENCSR226MTN (same as "neural_tube")
+        "neural_tube_unknown_stage": "ENCFF941SIQ",  # ENCSR414ZDH (timepoint not specified)
+    },
+    "DNASE": {
+        # ── Human cell lines ──
+        "HepG2":   "ENCFF615AKY",                    # ENCSR006CUK
+        "IMR-90":  "ENCFF515HBV",                    # ENCSR137OLC
+        "GM12878": "ENCFF673TIN",                    # ENCSR003WJE
+        "K562":    "ENCFF574YLK",                    # ENCSR296UHQ
+        "H1":      "ENCFF138PJQ",                    # ENCSR085MTT (NEW in v28)
+
+        # ── Mouse developmental atlas — bare-biosample defaults ──
+        "forelimb_bud": "ENCFF244FWC",               # ENCSR187FBX E11.5 (only stage)
+        "hindlimb_bud": "ENCFF676WUE",               # ENCSR293UHA E11.5 (NEW in v28)
+        "forebrain":    "ENCFF271AKE",               # ENCSR566UGU E11.5
+        "liver":        "ENCFF053FQE",               # ENCSR632SIB E14.5
+        "limb":         "ENCFF067XGA",               # ENCSR393JKG E11.5
+        "neural_tube":  "ENCFF541EGW",               # ENCSR432KJZ E11.5
+        "embryonic_facial_prominence": "ENCFF715EMI",  # ENCSR352WOM E11.5
+        "midbrain":     "ENCFF431PYL",               # ENCSR962UZB E14.5
+        "hindbrain":    "ENCFF186EHP",               # ENCSR797RNF E11.5
+
+        # ── Stage-suffixed mouse variants (new in v28) ──
+        "limb_E11.5":         "ENCFF067XGA",         # ENCSR393JKG (same as "limb")
+        "limb_E14.5":         "ENCFF275WOE",         # ENCSR551DHM
+        "liver_E11.5":        "ENCFF044WHP",         # ENCSR117PTY
+        "liver_E14.5":        "ENCFF053FQE",         # ENCSR632SIB (same as "liver")
+        "forebrain_E11.5":    "ENCFF271AKE",         # ENCSR566UGU (same as "forebrain")
+        "forebrain_E14.5":    "ENCFF251GBK",         # ENCSR491OUP
+        "midbrain_E11.5":     "ENCFF858GDY",         # ENCSR031VGX
+        "midbrain_E14.5":     "ENCFF431PYL",         # ENCSR962UZB (same as "midbrain")
+        "hindbrain_E11.5":    "ENCFF186EHP",         # ENCSR797RNF (same as "hindbrain")
+        "hindbrain_E14.5":    "ENCFF911DCI",         # ENCSR125VQW
+        "embryonic_facial_prominence_E11.5": "ENCFF715EMI",  # ENCSR352WOM (same as bare)
+        "embryonic_facial_prominence_E14.5": "ENCFF424ENU",  # ENCSR158PDD
+        "neural_tube_E11.5":  "ENCFF541EGW",         # ENCSR432KJZ (same as "neural_tube")
+    },
+    "CHIP": {},
+}
+
+
+def iter_unique_models():
+    """Iterate ``(assay, cell_type, encff_id)`` once per distinct ENCFF.
+
+    The registry above intentionally has aliases (e.g. ``"limb"``,
+    ``"limb_E12.5"``) that point to the same ENCFF tar. Callers that
+    iterate over every model — `discover_variant_effects`,
+    `scripts/build_backgrounds_chrombpnet.py` — should use this helper
+    to avoid loading the same weights N times. Returns the canonical
+    bare-biosample alias when one exists, otherwise the stage-suffixed
+    key.
+    """
+    seen: dict[str, tuple[str, str]] = {}
+    for assay in ("ATAC", "DNASE"):
+        for cell_type, encff in CHROMBPNET_MODELS_DICT.get(assay, {}).items():
+            key = f"{assay}:{encff}"
+            existing = seen.get(key)
+            # Prefer the shorter/bare name when an alias collision exists,
+            # so e.g. "limb" wins over "limb_E12.5" for the canonical row.
+            if existing is None or len(cell_type) < len(existing[1]):
+                seen[key] = (assay, cell_type)
+    for key, (assay, cell_type) in seen.items():
+        encff = key.split(":", 1)[1]
+        yield assay, cell_type, encff

--- a/scripts/build_backgrounds_chrombpnet.py
+++ b/scripts/build_backgrounds_chrombpnet.py
@@ -136,16 +136,16 @@ def load_models_and_setup():
 
     import tensorflow as tf
     import pysam
-    from chorus.oracles.chrombpnet_source.chrombpnet_globals import CHROMBPNET_MODELS_DICT
+    from chorus.oracles.chrombpnet_source.chrombpnet_globals import iter_unique_models
     from chorus.oracles.chrombpnet import ChromBPNetOracle
 
     ref_path = os.path.join(REPO_ROOT, "genomes/hg38.fa")
     ref = pysam.FastaFile(ref_path)
 
-    models_to_score = []
-    for assay in ('ATAC', 'DNASE'):
-        for cell_type in CHROMBPNET_MODELS_DICT.get(assay, {}):
-            models_to_score.append((assay, cell_type))
+    # Dedupe by ENCFF: registry has aliases ("limb" + "limb_E12.5"
+    # point to the same model). Without dedup we'd compute identical
+    # CDFs twice.
+    models_to_score = [(assay, ct) for assay, ct, _encff in iter_unique_models()]
     logger.info("Will score %d models (fold %d)", len(models_to_score), args.fold)
 
     oracle = ChromBPNetOracle(use_environment=False, reference_fasta=ref_path)


### PR DESCRIPTION
## Summary

v28 audit found chorus's `chrombpnet_globals.py` exposed only **24 of 42** ChromBPNet models ENCODE has published. Missing biosamples: **H1 DNase** (flagship hESC), **hindlimb_bud DNase**, plus 16 mouse-developmental stage variants of biosamples chorus only carried at one stage.

## What changed

**`chorus/oracles/chrombpnet_source/chrombpnet_globals.py`** — registry expanded:
- Backwards-compat: every existing key (`"limb"`, `"heart"`, `"K562"`, ...) still resolves to the same ENCFF as before
- New stage-suffixed keys: `"limb_E11.5"`, `"limb_E12.5"`, `"limb_E14.5"` etc.
- New biosamples: `"H1"` (DNase), `"hindlimb_bud"` (DNase), `"neural_tube_unknown_stage"` (ATAC)
- ATAC: 12 → 30 keys (22 distinct ENCFFs)
- DNase: 12 → 27 keys (20 distinct ENCFFs)
- **42 distinct ENCFFs total** (matches the live ENCODE Portal catalog at sync date)

**`iter_unique_models()`** — new helper that dedupes by ENCFF, preferring the bare-biosample alias as canonical. Used by:
- `chorus/analysis/discovery.py::discover_variant_effects` — without dedup, would double-load aliased models
- `scripts/build_backgrounds_chrombpnet.py` — avoids redundant CDF compute on a future GPU rebuild

## Source

ENCODE Portal annotation search:
```
https://www.encodeproject.org/search/?type=Annotation&annotation_type=ChromBPNet-model
```

43 annotations published as of 2026-04-25; 42 have model tars (ENCSR498NUZ retina DNase pending). Each duplicate biosample disambiguated by per-annotation `relevant_timepoint` lookup.

## Follow-up: rebuild + publish CDFs

The per-track CDF NPZ at `~/.chorus/backgrounds/chrombpnet_pertrack.npz` still has only 24 rows. The 18 new ENCFFs will predict normally but their percentile scoring returns `None` until rebuilt:

```bash
# On a GPU host:
mamba run -n chorus-chrombpnet python scripts/build_backgrounds_chrombpnet.py --part variants --gpu 0
mamba run -n chorus-chrombpnet python scripts/build_backgrounds_chrombpnet.py --part baselines --gpu 0
mamba run -n chorus python scripts/build_backgrounds_chrombpnet.py --part merge
# then upload the regenerated NPZ to huggingface.co/datasets/lucapinello/chorus-backgrounds
```

~2 hours of GPU compute (42 unique models × ~3 min each, after dedup). Deferred to the parallel agent on the GPU host. The HF write token has been provided out-of-band.

## Test plan

- [x] Registry static checks (42 distinct ENCFFs, all aliases resolve)
- [x] `iter_unique_models()` returns exactly 42, prefers bare biosample names
- [x] Fast pytest: 340 passed / 1 skipped (no regressions)
- [ ] Live load + predict for H1 DNase + limb_E14.5 — sandbox blocked; user can verify locally
- [ ] CDF rebuild + HF upload — follow-up on GPU host

🤖 Generated with [Claude Code](https://claude.com/claude-code)