### PR TITLE
Release 0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,163 @@
+# Changelog
+
+All notable changes to Chorus are documented here. The format follows
+[Keep a Changelog](https://keepachangelog.com/en/1.1.0/), and the
+project adheres to [Semantic Versioning](https://semver.org/).
+
+## [0.2.0] — 2026-04-27
+
+This release is the cumulative output of the v22 → v29 audit chain
+(spring 2026): six fresh-install audits, three scorched-earth replays
+on macOS arm64 + Linux/CUDA, and the BPNet/CHIP CDF rebuild that brings
+ChromBPNet's percentile-normalisation coverage from 24 → 786 tracks.
+
+### Added
+
+- **ChromBPNet/BPNet ENCODE catalogue expansion (PR #50)** — `chrombpnet_globals.py`
+  now exposes all 42 ENCODE-published ChromBPNet ATAC/DNase models
+  (was 24) plus the full 744 BPNet TF×cell-type models from the
+  JASPAR_DeepLearning 2026 release. New `iter_unique_models()` and
+  `iter_unique_bpnet_models()` helpers dedupe by ENCFF / (TF,cell)
+  for callers that want to iterate the catalogue.
+- **786-track ChromBPNet CDF NPZ on HuggingFace (PR #52, PR #53)** —
+  `lucapinello/chorus-backgrounds @ c1e5fc1` now contains effect /
+  summary / perbin CDFs for all 786 tracks (42 ATAC/DNASE + 744
+  BPNet/CHIP). Auto-downloaded by `chorus setup --oracle chrombpnet`.
+- **Sharded background-build pipeline (PR #51, PR #53)** — new
+  `--shard N --shard-of M` flags on `build_backgrounds_chrombpnet.py`
+  + `--part merge-shards` aggregator + the `scripts/run_bpnet_cdf_build.sh`
+  6-GPU orchestrator. Cuts a full BPNet rebuild from ~37 h on 1 GPU
+  to ~6 h across 6 GPUs.
+- **Incremental CDF append (PR #51, PR #52)** —
+  `PerTrackNormalizer.append_tracks()` deduplicates new track-IDs
+  against the existing NPZ and stitches new rows in place. Drives
+  the new `chorus backgrounds add-tracks --oracle X --npz <path>`
+  CLI subcommand.
+- **`chorus backgrounds` CLI subcommand group (PR #52)** — `status`,
+  `build`, and `add-tracks` for managing per-track CDF backgrounds
+  without leaving the shell.
+- **`chorus setup --all-chrombpnet` opt-in flag** — pre-cache every
+  one of the 786 ChromBPNet/BPNet models during setup (~30 GB extra,
+  3–4 h). Default behaviour stays on the v0.1 fast path (K562 +
+  HepG2 DNase only, ~1.4 GB).
+- **`chorus --version` flag** — was missing in 0.1.
+- **`EnvironmentNotReadyError`** — predict / load now raise a clear
+  actionable error pointing to `chorus setup` / `chorus health` when
+  `use_environment=True` was requested but the env wasn't built.
+  Replaces the earlier silent `use_environment=False` swallow.
+- **`docs/NORMALIZATION_GUIDE.md`** — full walkthrough of the per-track
+  CDF design, layer configs, and three end-to-end "bring your own
+  model" recipes (ChromBPNet, LegNet, new oracle from scratch).
+- **GitHub Actions CI** (`.github/workflows/tests.yml`) — runs the
+  fast pytest suite on every push and PR.
+- **End-to-end integration tests** (`tests/test_integration.py`) —
+  marker-gated SEI / LegNet CDF download, ChromBPNet fresh download,
+  and `chorus-mcp` stdio MCP E2E.
+- **Error-recovery unit tests** (`tests/test_error_recovery.py`) — 12
+  mock-based tests covering download/auth/env-missing failure paths.
+- **HTML walkthrough render audit** —
+  `audits/2026-04-26_v29_scorched_earth/probes/05_html_render.py`
+  renders all 18 shipped walkthroughs at 1600×4500 in headless
+  Chromium and audits each against the §7 audit checklist (IGV
+  block, glossary, percentile columns, formula badges, JS errors).
+
+### Changed
+
+- **README quickstart** rewritten to four numbered steps that read
+  in one lunch break (PR #42 + later refinements). Disk requirement
+  reduced from "~80 GB" to **~25 GB default / ~60 GB with
+  `--all-chrombpnet`** after the prefetch revert in PR #55.
+- **`chorus setup --oracle <X>` exit codes** — `chorus setup`,
+  `chorus health`, `chorus genome download`, `chorus remove` all
+  now return non-zero on bad input and surface the valid-name list.
+- **All "Failed to load X" exceptions** point at
+  `chorus health --oracle X` for diagnosis and end with a period.
+  HuggingFace-rejected-token errors point at
+  `https://huggingface.co/settings/tokens`.
+- **`--verbose` on `chorus health` / `list` / `genome`** now sets
+  the root logger to DEBUG (was previously a no-op aside from a few
+  extra print lines).
+- **Subprocess timeouts** raise `RuntimeError` with a pointer to
+  `CHORUS_NO_TIMEOUT=1` instead of bare `subprocess.TimeoutExpired`.
+- **`InvalidSequenceError`, `InvalidAssayError`, `InvalidRegionError`**
+  now multiply inherit from `ChorusError, ValueError` so legacy
+  `except ValueError` handlers still catch them.
+- **CLI noise demoted to DEBUG** — "Found mamba via MAMBA_EXE…" /
+  "Detected platform: Darwin arm64…" are no longer printed by every
+  command.
+- **TF/absl boot spam silenced** for Enformer + ChromBPNet via
+  `TF_CPP_MIN_LOG_LEVEL=3` set automatically inside the env runner.
+- **`chorus setup --oracle chrombpnet` default behaviour** reverted
+  to the v0.1 fast path (K562 + HepG2 DNase, ~9 min) after PR #55
+  found that PR #51's "all 786 models by default" change had silently
+  20×'d the default disk footprint and 20×'d setup time.
+
+### Fixed
+
+- **P0: track-ID validator rejected FANTOM CAGE identifiers**
+  (`CNhs11250` etc.) — Enformer/Borzoi `_validate_assay_ids` only
+  treated `ENCFF*` as identifier candidates, so the shipped
+  `single_oracle_quickstart.ipynb` broke on the first multi-track
+  cell for every new user. Fixed in PR #48.
+- **P0: `chorus-sei.yml` solver explosion** — old `cudatoolkit=11.7`
+  + `pytorch<2.0.0` pins triggered a 50-minute libsolv hang on
+  fresh installs. Removed in PR #46.
+- **P0: stale `pip install -e .` in README** — picked up a Python
+  2.7 `pip` from `~/.local/bin` on HPC PATHs. Replaced with
+  `python -m pip install -e .` in PR #46.
+- **P0: `_setup_environment` silently swallowed errors** — flipped
+  `use_environment=False` and continued. Now raises
+  `EnvironmentNotReadyError` on next predict.
+- **ChromBPNet HepG2 prefetch (P1)** — `chorus setup --oracle
+  chrombpnet` now pre-caches both K562 and HepG2 DNase models so
+  `advanced_multi_oracle_analysis` and `comprehensive_oracle_showcase`
+  notebooks don't block mid-run on a 720 MB ENCODE tarball.
+- **MCP `--help` listed 20 of 22 tools** — missed `discover_variant`
+  and `fine_map_causal_variant`. Reorganised into 4 logical groups
+  with explicit `(22)` count.
+- **Dead `#mcp-server-ai-assistant-integration` anchor** in
+  `MCP_WALKTHROUGH.md` — fixed to `#mcp-server`.
+- **Numerous error-message inconsistencies** — periods, fix hints,
+  `raise ChorusError` vs `logger.error + return False`, etc.
+
+### Documentation
+
+- **`docs/NORMALIZATION_GUIDE.md`** added (~700 lines).
+- **`docs/MCP_WALKTHROUGH.md`** — both install paths (`.mcp.json`
+  per-project + `claude mcp add` global) documented; added a
+  "verify the connection" first-prompt sanity check.
+- **README**: signed/unsigned tracks introduced before percentile
+  range; AlphaGenome 5,731-vs-5,168 disambiguated inline; Sei
+  21,907-vs-40 disambiguated inline; Apple Metal support claim
+  reconciled with the actual macOS GPU table.
+
+### Audits
+
+Six dated reports documenting the v22 → v29 cycle live under
+[`audits/`](audits/). The latest cross-platform validation is
+[`audits/2026-04-27_v29_linux_cuda/report.md`](audits/2026-04-27_v29_linux_cuda/report.md)
+(Linux/CUDA replay) which mirrors
+[`audits/2026-04-26_v29_scorched_earth/report.md`](audits/2026-04-26_v29_scorched_earth/report.md)
+(macOS arm64). Both returned 0 chorus findings.
+
+### Migration notes from 0.1.x
+
+- `chorus setup --oracle chrombpnet` will only pre-cache K562 + HepG2
+  DNase by default (~1.4 GB). Any other ChromBPNet cell type still
+  downloads on first `load_pretrained_model(...)`. To restore the
+  "everything up front" behaviour, pass `--all-chrombpnet`.
+- The default ChromBPNet CDF NPZ now has 786 rows (was 24). Any code
+  that hard-coded `track_ids` indices into the old NPZ should switch
+  to the dict-style `track_index[<id>]` lookup that
+  `PerTrackNormalizer` exposes.
+- `chorus-sei` env yml dropped `cudatoolkit=11.7` and bumped
+  `pytorch>=2.0.0`. If you have a manually pinned env, rebuild with
+  `chorus setup --oracle sei --force`.
+
+## [0.1.0] — 2025-09-XX
+
+Initial release: unified Python API + MCP server over six genomic
+deep-learning oracles (Enformer, Borzoi, ChromBPNet, Sei, LegNet,
+AlphaGenome). Per-oracle conda envs, per-track CDF normalization,
+HTML report generation with embedded IGV, and the `chorus` CLI
+(`setup`, `list`, `health`, `validate`, `remove`, `genome`).

--- a/chorus/__init__.py
+++ b/chorus/__init__.py
@@ -5,7 +5,7 @@ Chorus provides a consistent API for working with various genomic deep learning
 models including Enformer, Borzoi, ChromBPNet, and Sei.
 """
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 # ---------------------------------------------------------------------------
 # PATH guard for subprocess tools (bgzip, tabix, samtools)

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="chorus",
-    version="0.1.0",
+    version="0.2.0",
     author="Pinello Lab",
     author_email="lucapinello@gmail.com",
     description="A unified interface for genomic sequence oracles",


### PR DESCRIPTION
## Summary

Bumps version `0.1.0 → 0.2.0` and ships the first `CHANGELOG.md`.
After this merges, tag `v0.2.0` on main and create a GitHub release.

## What this version captures

The cumulative output of the v22 → v29 audit chain:

- ChromBPNet/BPNet ENCODE catalogue: **24 → 786 tracks**
- New `chorus backgrounds` CLI (`status` / `build` / `add-tracks`)
- Sharded GPU build pipeline + `--all-chrombpnet` opt-in
- 12 mock-based error-recovery tests + GitHub Actions fast-suite CI
- **3 consecutive scorched-earth audits (macOS + Linux/CUDA) with 0 findings against chorus**
- Docs rewritten for new-user onboarding (MCP, downloads, normalization, bring-your-own-model)
- Full migration notes from 0.1.x in CHANGELOG.md

## Files

- `CHANGELOG.md` (new, ~165 lines, Keep-a-Changelog format)
- `setup.py` — `version="0.2.0"`
- `chorus/__init__.py` — `__version__ = "0.2.0"`

## Test plan

- [x] `chorus --version` prints `chorus 0.2.0`
- [x] `import chorus; chorus.__version__ == "0.2.0"`
- [x] Fast pytest 340 / 1 (no regressions)
- [ ] After merge: `git tag v0.2.0 && git push origin v0.2.0`
- [ ] After tag: `gh release create v0.2.0 --notes-file CHANGELOG.md` (or curated subset)

🤖 Generated with [Claude Code](https://claude.com/claude-code)