### PR TITLE
Post-PR-#62 follow-ups: env-setup gating + equivalence-test rewrite (closes #63, #64, #65)

### DIFF
--- a/chorus/core/base.py
+++ b/chorus/core/base.py
@@ -121,15 +121,35 @@ class OracleBase(ABC):
                 # Validate environment
                 is_valid, issues = self._env_manager.validate_environment(self.oracle_name)
                 if not is_valid:
-                    msg = (
-                        f"Environment validation failed for {self.oracle_name}: "
-                        f"{'; '.join(issues)}. Run 'chorus health --oracle "
-                        f"{self.oracle_name}' to diagnose, or 'chorus setup "
-                        f"--oracle {self.oracle_name} --force' to rebuild."
+                    # Distinguish transient timeouts (slow NFS, cold-cache
+                    # `import jax`) from genuine missing-dep failures.
+                    # Genuine failures return fast and are real signal;
+                    # timeouts are not — the actual subprocess invocation
+                    # has its own per-call timeout and will surface a real
+                    # ModuleNotFoundError if the env is truly broken.
+                    # Issue #64.
+                    timeout_only = bool(issues) and all(
+                        i.startswith("Timeout while checking dependency")
+                        for i in issues
                     )
-                    logger.warning(msg)
-                    self._env_setup_error = msg
-                    self.use_environment = False
+                    if timeout_only:
+                        logger.warning(
+                            f"Environment validation for {self.oracle_name} "
+                            f"timed out ({'; '.join(issues)}). Proceeding "
+                            f"with use_environment=True; the actual run "
+                            f"will surface any real issue."
+                        )
+                        # Keep use_environment=True; do NOT set _env_setup_error.
+                    else:
+                        msg = (
+                            f"Environment validation failed for {self.oracle_name}: "
+                            f"{'; '.join(issues)}. Run 'chorus health --oracle "
+                            f"{self.oracle_name}' to diagnose, or 'chorus setup "
+                            f"--oracle {self.oracle_name} --force' to rebuild."
+                        )
+                        logger.warning(msg)
+                        self._env_setup_error = msg
+                        self.use_environment = False
                 else:
                     logger.info(f"Using conda environment: chorus-{self.oracle_name}")
         except ImportError as e:

--- a/chorus/oracles/alphagenome.py
+++ b/chorus/oracles/alphagenome.py
@@ -92,6 +92,9 @@ class AlphaGenomeOracle(OracleBase):
     # Model loading
     # ------------------------------------------------------------------
     def load_pretrained_model(self, weights: str = None) -> None:
+        # Raise EnvironmentNotReadyError up-front if env setup failed and
+        # the user explicitly asked for use_environment=True (issue #64).
+        self._check_env_ready()
         logger.info("Loading AlphaGenome model")
 
         if self.use_environment:

--- a/chorus/oracles/alphagenome_pt.py
+++ b/chorus/oracles/alphagenome_pt.py
@@ -142,6 +142,9 @@ class AlphaGenomePTOracle(OracleBase):
     # Loading
     # ------------------------------------------------------------------
     def load_pretrained_model(self, weights: str = None) -> None:
+        # Raise EnvironmentNotReadyError up-front if env setup failed and
+        # the user explicitly asked for use_environment=True (issue #64).
+        self._check_env_ready()
         logger.info("Loading AlphaGenome PyTorch port")
         if self.use_environment:
             self._load_in_environment(weights)

--- a/chorus/oracles/borzoi.py
+++ b/chorus/oracles/borzoi.py
@@ -71,8 +71,11 @@ class BorzoiOracle(OracleBase):
         return ""
     
     def load_pretrained_model(self, weights: str = None) -> None:
+        # Raise EnvironmentNotReadyError up-front if env setup failed and
+        # the user explicitly asked for use_environment=True (issue #64).
+        self._check_env_ready()
         logger.info(f"Loading Borzoi model fold {self.fold}")
-        
+
         if self.use_environment:
             self._load_in_environment(weights)
         else:

--- a/chorus/oracles/chrombpnet.py
+++ b/chorus/oracles/chrombpnet.py
@@ -384,6 +384,9 @@ class ChromBPNetOracle(OracleBase):
         ``model_type='chrombpnet'`` explicitly for the bias-aware
         variant; that path falls back to the full ENCODE tarball.
         """
+        # Raise EnvironmentNotReadyError up-front if env setup failed and
+        # the user explicitly asked for use_environment=True (issue #64).
+        self._check_env_ready()
 
         if assay is None or cell_type is None:
             raise InvalidAssayError(

--- a/chorus/oracles/enformer.py
+++ b/chorus/oracles/enformer.py
@@ -101,6 +101,9 @@ class EnformerOracle(OracleBase):
     
     def load_pretrained_model(self, weights: str = None) -> None:
         """Load Enformer model in the appropriate environment."""
+        # Raise EnvironmentNotReadyError up-front if env setup failed and
+        # the user explicitly asked for use_environment=True (issue #64).
+        self._check_env_ready()
         if weights is None:
             weights = self.get_model_weights_path()
         

--- a/chorus/oracles/legnet.py
+++ b/chorus/oracles/legnet.py
@@ -115,6 +115,9 @@ class LegNetOracle(OracleBase):
     
     def load_pretrained_model(self, weights: str | None = None) -> None:
         """Load LegNet model weights."""
+        # Raise EnvironmentNotReadyError up-front if env setup failed and
+        # the user explicitly asked for use_environment=True (issue #64).
+        self._check_env_ready()
         if weights is not None:
             self.model_dir = weights
 

--- a/chorus/oracles/sei.py
+++ b/chorus/oracles/sei.py
@@ -127,6 +127,9 @@ class SeiOracle(OracleBase):
     
     def load_pretrained_model(self, weights: str | None = None) -> None:
         """Load Sei model weights."""
+        # Raise EnvironmentNotReadyError up-front if env setup failed and
+        # the user explicitly asked for use_environment=True (issue #64).
+        self._check_env_ready()
         if weights is not None:
             self.model_dir = weights
 

--- a/tests/test_alphagenome_backends_equivalence.py
+++ b/tests/test_alphagenome_backends_equivalence.py
@@ -1,171 +1,126 @@
 """Numerical equivalence between AlphaGenome JAX and PyTorch backends.
 
 Gated with ``@pytest.mark.integration`` — runs both backends inside their
-respective conda envs, predicts a 1 MB SORT1 window with each, and asserts
-the per-track outputs agree within tolerance.
+respective conda envs via chorus's normal Oracle API, predicts a 1 MB
+SORT1 window with each, and asserts per-track agreement.
 
-Run from the repo root:
+Run from the repo root::
 
     pytest tests/test_alphagenome_backends_equivalence.py -m integration -v
 
-Skips automatically if either env is missing.
+Skips automatically if either env or the hg38 reference is missing.
+
+History
+-------
+The original test (pre-#63) compared JAX and PyTorch outputs at the
+*raw model head*. JAX's DNase head exposes 305 tracks and the PyTorch
+port's exposes 384 — they're different upstream filtering choices,
+not different weights. The shape-parity assertion was bound to fail
+on any platform; it just didn't surface until the Linux/CUDA spot-check
+on `audit/linux-cuda-pr62`.
+
+The fix is to compare at the chorus-API layer instead. ``oracle.predict()``
+goes through ``_local_index`` slicing in
+``chorus/oracles/alphagenome.py:_predict``, which selects the user-
+requested tracks by identifier from the shared 5,731-track metadata
+cache (`alphagenome_tracks.json`) — so post-slicing arrays are
+shape-compatible across backends regardless of raw-head shape. Closes
+#63 (raw-head shape mismatch) and #65 (eliminates the bare-`mamba`
+subprocess calls that broke when this test was invoked under
+``mamba run -n chorus pytest``).
 """
 from __future__ import annotations
 
-import json
-import os
-import subprocess
-import textwrap
 from pathlib import Path
 
 import numpy as np
 import pytest
 
 
+# 1 MB SORT1 window centered at rs12740374's TSS (chr1:109,274,968).
+# Same window as the v30 macOS audit and the audit/linux-cuda-pr62 audit
+# so the equivalence numbers stay comparable.
 SORT1_WINDOW = (
     "chr1",
     109_274_968 - 524_288,
     109_274_968 + 524_288,
 )
+
 GENOME_FASTA = Path(__file__).parent.parent / "genomes" / "hg38.fa"
 
-
-def _env_exists(env_name: str) -> bool:
-    try:
-        out = subprocess.run(
-            ["mamba", "env", "list", "--json"],
-            capture_output=True, text=True, check=True,
-        )
-        envs = json.loads(out.stdout).get("envs", [])
-        return any(env_name == os.path.basename(p) for p in envs)
-    except Exception:
-        return False
-
-
-PT_RUNNER = textwrap.dedent(
-    r"""
-    import os, sys, json, numpy as np
-    os.environ.setdefault("KMP_DUPLICATE_LIB_OK", "TRUE")
-    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
-
-    args = json.loads(sys.argv[1])
-    fasta = args["fasta"]; chrom = args["chrom"]
-    start = args["start"]; end = args["end"]; device_name = args["device"]
-
-    import pyfaidx
-    seq = str(pyfaidx.Fasta(fasta)[chrom][start:end]).upper()
-    seq = seq.strip("N")
-    # round to nearest power of 2 in [2**15, 2**20]
-    valid = [2**p for p in range(15, 21)]
-    target = max(v for v in valid if v <= len(seq))
-    trim = (len(seq) - target) // 2
-    seq = seq[trim:trim + target]
-
-    import torch, huggingface_hub
-    from alphagenome_pytorch import AlphaGenome
-
-    weights = huggingface_hub.hf_hub_download("gtca/alphagenome_pytorch", "model_all_folds.safetensors")
-    device = torch.device(device_name)
-    model = AlphaGenome.from_pretrained(weights, device=device); model.eval()
-
-    arr = np.zeros((len(seq), 4), dtype=np.float32)
-    for i, b in enumerate(seq):
-        j = "ACGT".find(b)
-        if j >= 0: arr[i, j] = 1.0
-    x = torch.from_numpy(arr).unsqueeze(0).to(device)
-    org = torch.tensor([0], dtype=torch.long, device=device)
-    with torch.no_grad():
-        out = model(x, organism_index=org, heads=("atac","dnase"))
-    dnase_1 = out["dnase"][1][0].detach().cpu().numpy()  # (L, n_tracks)
-    np.savez_compressed(args["out"], dnase_1=dnase_1)
-    print(json.dumps({"length": len(seq), "shape": list(dnase_1.shape)}))
-    """
-)
-
-
-JAX_RUNNER = textwrap.dedent(
-    r"""
-    import os, sys, json, platform, numpy as np
-    if platform.system() == "Darwin":
-        os.environ["JAX_PLATFORMS"] = "cpu"
-
-    args = json.loads(sys.argv[1])
-    fasta = args["fasta"]; chrom = args["chrom"]
-    start = args["start"]; end = args["end"]
-
-    import pyfaidx
-    seq = str(pyfaidx.Fasta(fasta)[chrom][start:end]).upper()
-    seq = seq.strip("N")
-    valid = [2**p for p in range(15, 21)]
-    target = max(v for v in valid if v <= len(seq))
-    trim = (len(seq) - target) // 2
-    seq = seq[trim:trim + target]
-
-    import jax
-    from alphagenome.models.dna_output import OutputType
-    from alphagenome_research.model.dna_model import create_from_huggingface
-    jax_device = jax.devices("cpu")[0]
-    model = create_from_huggingface("all_folds", device=jax_device)
-    out = model.predict_sequence(seq, requested_outputs=[OutputType.DNASE], ontology_terms=None)
-    dnase = np.asarray(out[OutputType.DNASE].values)  # (L, n_tracks)
-    np.savez_compressed(args["out"], dnase=dnase)
-    print(json.dumps({"length": len(seq), "shape": list(dnase.shape)}))
-    """
-)
-
-
-def _run(env: str, code: str, args: dict, tmp_out: Path) -> dict:
-    args = {**args, "out": str(tmp_out)}
-    r = subprocess.run(
-        ["mamba", "run", "-n", env, "python", "-c", code, json.dumps(args)],
-        capture_output=True, text=True, timeout=1800,
-    )
-    if r.returncode != 0:
-        raise RuntimeError(f"subprocess in {env} failed:\n{r.stderr}")
-    last = next(l for l in reversed(r.stdout.strip().splitlines()) if l.startswith("{"))
-    return json.loads(last)
+# Three canonical AlphaGenome assay identifiers (format
+# "{output_type}/{name}/{strand}", verified via
+# chorus.oracles.alphagenome_source.alphagenome_metadata.get_metadata().search_tracks).
+# Same K562 / HepG2 / hepatocyte set used in the v30 macOS Tier-1 audit.
+ASSAY_IDS = [
+    "DNASE/EFO:0002067 DNase-seq/.",   # K562 DNase
+    "DNASE/EFO:0001187 DNase-seq/.",   # HepG2 DNase
+    "DNASE/CL:0000182 DNase-seq/.",    # hepatocyte DNase
+]
 
 
 @pytest.mark.integration
-def test_jax_pt_dnase_equivalence_at_sort1(tmp_path):
-    """JAX and PyTorch backends should agree on DNase predictions at the
-    SORT1 locus to within tight tolerance.
+def test_jax_pt_chorus_api_equivalence_at_sort1():
+    """JAX and PyTorch AlphaGenome backends produce equivalent chorus-API outputs.
 
-    The PyTorch port's README claims per-head + full-forward equivalence
-    against the JAX checkpoint. This test pins that claim against actual
-    chorus inputs (one assay, one canonical region) so a future weight
-    refresh upstream doesn't silently drift our results.
+    Compares the ``oracle.predict()`` output array per assay — chorus's
+    ``local_index`` slicing maps the user-requested identifier to the
+    same logical track on both backends, so post-slicing arrays are
+    shape-compatible regardless of raw head shape. Tolerances:
+    ``max(|pt - jax|) < 0.1`` (absolute), ``mean rel < 5%``. The v30
+    macOS and Linux/CUDA audits both reported 0.74–1.85 % per-track
+    relative error, well inside this bound.
     """
     if not GENOME_FASTA.exists():
-        pytest.skip("hg38.fa not present — `chorus genome download hg38` first")
-    if not _env_exists("chorus-alphagenome"):
-        pytest.skip("chorus-alphagenome env missing")
-    if not _env_exists("chorus-alphagenome_pt"):
-        pytest.skip("chorus-alphagenome_pt env missing")
+        pytest.skip(
+            "hg38.fa not present — run `chorus genome download hg38` first"
+        )
 
-    chrom, start, end = SORT1_WINDOW
-    pt_out = tmp_path / "pt.npz"
-    jax_out = tmp_path / "jax.npz"
+    # Skip cleanly when either env is missing — uses chorus's own
+    # EnvironmentManager so we resolve `mamba`/`conda` the same way the
+    # framework does (handles `mamba run` invocation, MAMBA_EXE, etc.).
+    from chorus.core.environment import EnvironmentManager
 
-    base_args = {
-        "fasta": str(GENOME_FASTA),
-        "chrom": chrom, "start": start, "end": end,
-    }
-    _run("chorus-alphagenome_pt", PT_RUNNER,
-         {**base_args, "device": "cpu"}, pt_out)
-    _run("chorus-alphagenome", JAX_RUNNER, base_args, jax_out)
+    mgr = EnvironmentManager()
+    for env in ("alphagenome", "alphagenome_pt"):
+        if not mgr.environment_exists(env):
+            pytest.skip(f"chorus-{env} env missing")
 
-    pt = np.load(pt_out)["dnase_1"]
-    jx = np.load(jax_out)["dnase"]
+    import chorus
 
-    # Shapes should match (L, n_tracks). PyTorch returns (L, n_tracks)
-    # at resolution 1 — same as JAX's predict_sequence per-track output.
-    assert pt.shape == jx.shape, f"shape mismatch: pt={pt.shape} jax={jx.shape}"
+    preds = {}
+    for name in ("alphagenome", "alphagenome_pt"):
+        oracle = chorus.create_oracle(
+            name,
+            use_environment=True,
+            reference_fasta=str(GENOME_FASTA),
+        )
+        oracle.load_pretrained_model()
+        preds[name] = oracle.predict(SORT1_WINDOW, ASSAY_IDS)
 
-    # Per-track absolute and relative tolerances. Upstream claims numerical
-    # equivalence; we pin a generous bound so weight conversions or attn
-    # numerics changes get flagged but minor implementation drift doesn't.
-    abs_diff = np.abs(pt - jx).max()
-    rel_diff = np.abs(pt - jx).mean() / (np.abs(jx).mean() + 1e-9)
-    assert abs_diff < 0.1, f"max abs diff {abs_diff:.4f} exceeds 0.1"
-    assert rel_diff < 0.05, f"mean rel diff {rel_diff:.4f} exceeds 5%"
+    for aid in ASSAY_IDS:
+        jax_track = preds["alphagenome"][aid]
+        pt_track = preds["alphagenome_pt"][aid]
+        a = jax_track.values
+        b = pt_track.values
+
+        assert a.shape == b.shape, (
+            f"{aid}: chorus-API per-track shape mismatch "
+            f"(jax={a.shape}, pt={b.shape}). The local_index slicing was "
+            f"supposed to align both backends — investigate metadata."
+        )
+        assert a.ndim == 1, (
+            f"{aid}: per-track values should be 1-D after slicing, got {a.shape}"
+        )
+
+        max_abs = float(np.abs(a - b).max())
+        mean_rel = float(np.abs(a - b).mean() / (np.abs(a).mean() + 1e-9))
+
+        assert max_abs < 0.1, (
+            f"{aid}: max abs diff {max_abs:.4f} exceeds 0.1 — JAX vs PyTorch "
+            f"backend drift. Audit numbers from PR #62 were < 0.05."
+        )
+        assert mean_rel < 0.05, (
+            f"{aid}: mean rel diff {mean_rel:.4f} exceeds 5% — JAX vs "
+            f"PyTorch backend drift. Audit numbers from PR #62 were < 2%."
+        )

--- a/tests/test_environment_setup_gating.py
+++ b/tests/test_environment_setup_gating.py
@@ -1,0 +1,125 @@
+"""Pin the env-setup gating policy in `OracleBase._setup_environment`.
+
+Issue #64 — chorus's env validator at `chorus/core/environment/manager.py`
+has a 60 s probe timeout. On cold-NFS lab boxes a `python -c "import jax"`
+probe regularly times out even though the env is healthy. The base class
+used to silently downgrade `use_environment=True → False` on every
+validation failure (including timeouts), then `oracle.load_pretrained_model()`
+would crash with `ModuleNotFoundError` because `_load_direct` tried to
+import the framework dep in the chorus base env.
+
+The fix distinguishes the two failure modes:
+
+1. **Timeout-only failures**: log a warning, keep `use_environment=True`.
+   The actual subprocess invocation has its own per-call timeout and
+   will surface a real error if the env is genuinely broken.
+2. **Genuine missing-dep failures**: keep the downgrade + raise
+   `EnvironmentNotReadyError` from the next user-facing call (preserves
+   the v26 P1 #11 invariant — users who passed `use_environment=True`
+   never silently fall back to the wrong env).
+
+These tests pin both branches without building a real conda env or
+needing a GPU. They run in the default fast suite.
+"""
+from __future__ import annotations
+
+import pytest
+
+from chorus.core.exceptions import EnvironmentNotReadyError
+from chorus.oracles.alphagenome import AlphaGenomeOracle
+
+
+def _patch_validation(monkeypatch, issues):
+    """Stub `EnvironmentManager.environment_exists` (returns True so we
+    reach the validation step) and `validate_environment` (returns the
+    given issues so we exercise the failure branch). Return value lets
+    the construction call reach `_setup_environment`'s validation block."""
+    from chorus.core.environment import manager as _mgr
+
+    monkeypatch.setattr(
+        _mgr.EnvironmentManager, "environment_exists", lambda self, oracle: True
+    )
+    monkeypatch.setattr(
+        _mgr.EnvironmentManager,
+        "validate_environment",
+        lambda self, oracle: (False, issues),
+    )
+
+
+def test_validation_timeout_does_not_downgrade(monkeypatch):
+    """Timeout-only failures must NOT flip use_environment=True → False
+    and must NOT set _env_setup_error. Cold-NFS / slow-import probes are
+    not a useful signal of env brokenness."""
+    _patch_validation(monkeypatch, ["Timeout while checking dependency jax"])
+
+    oracle = AlphaGenomeOracle(use_environment=True)
+
+    assert oracle.use_environment is True, (
+        "Validation timeout should leave use_environment=True so the "
+        "user's explicit request is honored. Genuine missing-dep failures "
+        "are a separate branch (see test_validation_missing_dep_raises)."
+    )
+    assert getattr(oracle, "_env_setup_error", None) is None, (
+        "_env_setup_error should be None on timeout — only genuine "
+        "failures populate it."
+    )
+
+
+def test_validation_missing_dep_raises_on_load(monkeypatch):
+    """Genuine missing-dep failures must downgrade use_environment AND
+    cause `load_pretrained_model()` to raise `EnvironmentNotReadyError`.
+    This pins both the downgrade behavior (v26 P1 #11) and the gap fix
+    (each oracle's load_pretrained_model now calls _check_env_ready).
+    """
+    _patch_validation(
+        monkeypatch, ["Missing dependency jax: not importable"]
+    )
+
+    oracle = AlphaGenomeOracle(use_environment=True)
+    assert oracle.use_environment is False, (
+        "Genuine missing-dep failure must downgrade use_environment so "
+        "the next user-facing call surfaces the failure clearly."
+    )
+    assert oracle._env_setup_error is not None
+    assert "Missing dependency" in oracle._env_setup_error
+
+    with pytest.raises(EnvironmentNotReadyError):
+        oracle.load_pretrained_model()
+
+
+def test_validation_mixed_issues_treated_as_genuine_failure(monkeypatch):
+    """If issues include both a timeout AND a real missing-dep, treat as
+    genuine failure (the missing-dep is the real signal). Pin the
+    'all-timeouts' check is conjunctive."""
+    _patch_validation(
+        monkeypatch,
+        [
+            "Timeout while checking dependency jax",
+            "Missing dependency tensorflow: not importable",
+        ],
+    )
+
+    oracle = AlphaGenomeOracle(use_environment=True)
+    assert oracle.use_environment is False
+    assert oracle._env_setup_error is not None
+
+
+def test_use_environment_false_skips_validation_entirely(monkeypatch):
+    """When the user passes use_environment=False at construction, the
+    validation path should not run — there's nothing to validate. Pin
+    that the v26 P1 #11 raise gate (`_user_asked_for_env`) doesn't fire
+    in the test/library-internal path."""
+    # Make validate_environment explode if it's called — it shouldn't be.
+    from chorus.core.environment import manager as _mgr
+
+    def _boom(self, oracle):  # pragma: no cover — should not execute
+        raise AssertionError("validate_environment should not be called when use_environment=False")
+
+    monkeypatch.setattr(_mgr.EnvironmentManager, "validate_environment", _boom)
+
+    oracle = AlphaGenomeOracle(use_environment=False)
+    assert oracle.use_environment is False
+    # _check_env_ready should not raise even with err set, because
+    # _user_asked_for_env is False.
+    oracle._env_setup_error = "synthetic"
+    oracle._check_env_ready()  # must not raise


### PR DESCRIPTION
Closes #63, #64, #65 — the three follow-ups from PR #62's Linux/CUDA spot-check audit. Tightly coupled, so handled together.

## Summary

Two commits, three issues:

### `bc923b4` — fix(env-setup): timeout-soft policy + plug load_pretrained_model gate (#64)

**Two fixes that should have been one:**

1. `chorus/core/base.py:_setup_environment` now distinguishes transient validation timeouts (slow NFS / cold-cache `import jax` probes) from genuine missing-dep failures. Timeout-only failures keep `use_environment=True`; genuine failures keep the v26 P1 #11 invariant (downgrade + raise on next user call).

2. Each oracle's `load_pretrained_model` now calls `self._check_env_ready()` as its first action (7 oracles, 1-line edit each). `predict()` already did this; `load_pretrained_model` didn't, so a silent downgrade still surfaced as `ModuleNotFoundError` from `_load_direct` instead of the intended `EnvironmentNotReadyError`.

3. `tests/test_environment_setup_gating.py` — 4 fast-suite tests pinning both branches without building real conda envs. Run in <2 s.

The audit-script workaround (`o.use_environment = True; o._env_setup_error = None`) is no longer needed.

### `fe9b08d` — test(alphagenome): rewrite equivalence test via chorus API (#63, #65)

The pre-rewrite test compared JAX and PyTorch at the **raw model head** and asserted shape parity. JAX exposes 305 DNase tracks and PyTorch exposes 384 — different upstream filtering, not different weights. Shape assertion was bound to fail on any platform.

Rewrite:
- Uses `oracle.predict()` which goes through chorus's `local_index` slicing — post-slicing arrays are shape-compatible across backends regardless of raw head shape.
- Drops the ~70-line `JAX_RUNNER` + `PT_RUNNER` subprocess heredocs.
- Drops bare `subprocess.run([\"mamba\", ...])` calls (closes #65).
- Uses `EnvironmentManager.environment_exists()` for skip detection (chorus's own resolver handles `MAMBA_EXE` / `shutil.which` / fallback chain).
- Hardcodes 3 canonical DNase identifiers (K562, HepG2, hepatocyte) verified against `alphagenome_metadata.search_tracks()` at write time.
- Tolerances unchanged: `max(|pt - jax|) < 0.1`, mean rel < 5%.

## Test plan

- [x] **Fast suite locally**: 368 passed, 1 skipped (was 364) — +4 new gating tests
- [ ] **Linux CI**: should pass on the same fast-suite criterion
- [ ] **macOS integration**: `pytest tests/test_alphagenome_backends_equivalence.py -m integration -v` — both backends must produce equivalent outputs at SORT1 (audit numbers were 0.74–1.85% per-track rel diff)
- [ ] **Linux/CUDA integration on user's other box**: same command, no `o.use_environment = True; o._env_setup_error = None` workaround needed
- [ ] **Manual smoke for #64**: on a slow-NFS box, `chorus.create_oracle('alphagenome', use_environment=True)` should log a single timeout warning and `oracle.use_environment` should still be True afterward; subsequent `oracle.load_pretrained_model()` should NOT raise `ModuleNotFoundError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)