### PR TITLE
fix(health): recognise slim HF mirror for chrombpnet + add alphagenome_pt probe

### DIFF
--- a/chorus/core/weights_probe.py
+++ b/chorus/core/weights_probe.py
@@ -49,13 +49,53 @@ def _probe_legnet() -> Tuple[bool, List[str]]:
     return (True, [])
 
 
+def _hf_cache_dir() -> Path:
+    """Resolve the HuggingFace hub cache directory.
+
+    Prefer the canonical ``huggingface_hub.constants.HF_HUB_CACHE`` (which
+    honours ``HF_HOME`` / ``HF_HUB_CACHE`` env vars); fall back to the
+    documented default ``~/.cache/huggingface/hub`` if the import fails
+    (chorus base env always has huggingface_hub, so the fallback is
+    defensive).
+    """
+    try:
+        from huggingface_hub.constants import HF_HUB_CACHE
+        return Path(HF_HUB_CACHE)
+    except Exception:
+        return Path.home() / ".cache" / "huggingface" / "hub"
+
+
 def _probe_chrombpnet() -> Tuple[bool, List[str]]:
-    # ChromBPNet has no constructor-level default; `chorus setup chrombpnet`
-    # pre-downloads the canonical DNASE / K562 model.
-    default = CHORUS_DOWNLOADS_DIR / "chrombpnet" / "DNASE_K562"
-    if not default.exists() or not any(default.iterdir()):
-        return (False, [str(default)])
-    return (True, [])
+    """Accept either the 0.3.0+ slim HF mirror or the legacy ENCODE-tarball
+    layout as proof of install.
+
+    Default in 0.3.0+: weights stream from
+    ``lucapinello/chorus-chrombpnet-slim`` and live in the HF hub cache.
+    The local ``downloads/chrombpnet/DNASE_K562`` directory is only
+    populated for users who explicitly request ``model_type='chrombpnet'``
+    (bias-aware) or fold ≠ 0, both of which fall back to ENCODE tarballs.
+    `chorus setup chrombpnet` succeeds on the slim path, so we must
+    accept either cache as installed.
+    """
+    # 0.3.0+ default: slim HF mirror.
+    slim_snapshots = (
+        _hf_cache_dir() / "models--lucapinello--chorus-chrombpnet-slim" / "snapshots"
+    )
+    if slim_snapshots.exists():
+        for snap in slim_snapshots.iterdir():
+            if (snap / "manifest.json").exists():
+                return (True, [])
+    # Legacy ENCODE-tarball cache.
+    legacy = CHORUS_DOWNLOADS_DIR / "chrombpnet" / "DNASE_K562"
+    if legacy.exists() and any(legacy.iterdir()):
+        return (True, [])
+    return (
+        False,
+        [
+            f"neither HF slim mirror cache ({slim_snapshots.parent}) "
+            f"nor legacy {legacy} is populated"
+        ],
+    )
 
 
 def _probe_alphagenome() -> Tuple[bool, List[str]]:
@@ -88,11 +128,32 @@ def _probe_library_cached() -> Tuple[bool, List[str]]:
     return (True, [])
 
 
+def _probe_alphagenome_pt() -> Tuple[bool, List[str]]:
+    """Check the HF cache for the upstream PyTorch port's safetensors.
+
+    Weights live at ``models--gtca--alphagenome_pytorch/snapshots/<rev>/
+    model_all_folds.safetensors`` after ``chorus setup --oracle
+    alphagenome_pt`` (or the first ``load_pretrained_model()`` call).
+    """
+    pt_snapshots = (
+        _hf_cache_dir() / "models--gtca--alphagenome_pytorch" / "snapshots"
+    )
+    if pt_snapshots.exists():
+        for snap in pt_snapshots.iterdir():
+            if any(p.suffix == ".safetensors" for p in snap.iterdir()):
+                return (True, [])
+    return (
+        False,
+        [f"HF cache not populated: {pt_snapshots.parent}"],
+    )
+
+
 _ARTIFACT_PROBES: Dict[str, Callable[[], Tuple[bool, List[str]]]] = {
     "sei": _probe_sei,
     "legnet": _probe_legnet,
     "chrombpnet": _probe_chrombpnet,
     "alphagenome": _probe_alphagenome,
+    "alphagenome_pt": _probe_alphagenome_pt,
     "enformer": _probe_library_cached,
     "borzoi": _probe_library_cached,
 }


### PR DESCRIPTION
# fix(health): recognise slim HF mirror for chrombpnet + add alphagenome_pt probe

Two stale checks in `chorus/core/weights_probe.py` were causing `chorus health` to falsely report healthy 0.4.0 installs as `⚠ Not installed`.

## Symptom

On a fresh `chorus setup --oracle all` against 0.4.0:

```
✓ alphagenome: Healthy
⚠ alphagenome_pt: Not installed — run `chorus setup alphagenome_pt`
✓ borzoi: Healthy
⚠ chrombpnet: Not installed — run `chorus setup chrombpnet`
✓ enformer: Healthy
✓ legnet: Healthy
✓ sei: Healthy
```

…even though both flagged oracles load and predict cleanly (`oracle.load_pretrained_model()` succeeds in <8 s, end-to-end `oracle._predict()` returns the expected outputs). I.e. the runtime path is fine; only the probe is stale.

## Root cause

1. **chrombpnet probe** (`_probe_chrombpnet`) was looking at the legacy ENCODE-tarball-extracted directory:
   ```python
   default = CHORUS_DOWNLOADS_DIR / "chrombpnet" / "DNASE_K562"
   if not default.exists() or not any(default.iterdir()):
       return (False, [str(default)])
   ```
   In 0.3.0+ that directory is empty by default — chrombpnet weights stream from the slim HF mirror at `lucapinello/chorus-chrombpnet-slim` (#59 / #60). The legacy directory only gets populated if a user explicitly requests `model_type='chrombpnet'` (bias-aware) or `fold ≠ 0`, both of which fall through to ENCODE.

2. **alphagenome_pt** was missing from `_ARTIFACT_PROBES` entirely. The oracle was added to the registry in #62 but the health probe was never updated. So the probe-dispatcher never had an entry for it; it always fell through to the missing-marker code path.

## Fix

1. **`_probe_chrombpnet`**: accept *either* the slim-mirror snapshot cache (`manifest.json` present under `models--lucapinello--chorus-chrombpnet-slim/snapshots/<rev>/`) *or* the legacy ENCODE directory.
2. **New `_probe_alphagenome_pt`**: checks the HF cache at `models--gtca--alphagenome_pytorch/snapshots/<rev>/*.safetensors` (the upstream port's published weights).
3. **New `_hf_cache_dir()` helper**: both new probes route through it so they honour `HF_HOME` / `HF_HUB_CACHE` env vars via `huggingface_hub.constants.HF_HUB_CACHE`, with a defensive fallback to `~/.cache/huggingface/hub`.

## Verification

End-to-end on macOS arm64:

```
$ chorus health
✓ alphagenome: Healthy
✓ alphagenome_pt: Healthy
✓ borzoi: Healthy
✓ chrombpnet: Healthy
✓ enformer: Healthy
✓ legnet: Healthy
✓ sei: Healthy
```

7/7 ✓, was 5/7 before.

`pytest -m "not integration and not slow"`: **368 passed, 1 skipped, 5 deselected** (no regression).

## Out of scope

- A regression test for the probe logic. Would need either an integration-marked test that actually invokes `chorus health` after setup, or a unit test that mocks the HF cache path. Tracked as a follow-up; the fix itself is small enough to inspect by reading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
