### PR TITLE
fix(v0.5.1): chrombpnet wide-window predict in base env + alphagenome_pt log noise

### DIFF
--- a/chorus/__init__.py
+++ b/chorus/__init__.py
@@ -5,7 +5,7 @@ Chorus provides a consistent API for working with various genomic deep learning
 models including Enformer, Borzoi, ChromBPNet, and Sei.
 """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 # ---------------------------------------------------------------------------
 # PATH guard for subprocess tools (bgzip, tabix, samtools)

--- a/chorus/analysis/normalization.py
+++ b/chorus/analysis/normalization.py
@@ -1014,6 +1014,12 @@ def download_pertrack_backgrounds(
     bg_dir = Path(cache_dir)
     bg_dir.mkdir(parents=True, exist_ok=True)
 
+    # alphagenome_pt aliases to alphagenome's NPZ — there is no separate
+    # alphagenome_pt_pertrack.npz on HF.  Skip the download attempt (the
+    # 404 is expected) and let the caller's alias-aware lookup take over.
+    if oracle_name in PerTrackNormalizer._CDF_ALIASES:
+        return 0
+
     fname = PerTrackNormalizer.npz_filename(oracle_name)
     local_path = bg_dir / fname
     if local_path.exists():

--- a/chorus/cli/_backgrounds.py
+++ b/chorus/cli/_backgrounds.py
@@ -19,9 +19,13 @@ logger = logging.getLogger(__name__)
 
 _BG_DIR = Path.home() / ".chorus" / "backgrounds"
 
-# Oracles that have per-track NPZ backgrounds
+# Oracles that have per-track NPZ backgrounds.  alphagenome_pt aliases
+# to alphagenome's NPZ at lookup time (`PerTrackNormalizer._CDF_ALIASES`),
+# but for the status table we still want a row showing the alias is
+# active so users don't think the alphagenome_pt env is missing data.
 _KNOWN_ORACLES = [
-    "enformer", "borzoi", "chrombpnet", "sei", "legnet", "alphagenome",
+    "enformer", "borzoi", "chrombpnet", "sei", "legnet",
+    "alphagenome", "alphagenome_pt",
 ]
 
 

--- a/chorus/cli/_setup_prefetch.py
+++ b/chorus/cli/_setup_prefetch.py
@@ -225,7 +225,19 @@ def prefetch_backgrounds(oracle: str) -> Tuple[bool, Optional[str]]:
         return (False, f"Download failed: {exc}.")
 
     if n == 0:
-        logger.info("Backgrounds for %s already cached (or unavailable)", oracle)
+        # Special case: alphagenome_pt has no NPZ of its own — it aliases
+        # to alphagenome's CDFs at lookup time
+        # (`PerTrackNormalizer._CDF_ALIASES`).  Don't warn about the 404,
+        # mention the alias instead so users don't think setup half-failed.
+        if oracle == "alphagenome_pt":
+            logger.info(
+                "Backgrounds for %s alias to 'alphagenome' "
+                "(no separate NPZ — same model, different backend)", oracle,
+            )
+        else:
+            logger.info(
+                "Backgrounds for %s already cached (or unavailable)", oracle,
+            )
     else:
         logger.info("✓ pulled %d background file(s) for %s", n, oracle)
     return (True, None)

--- a/chorus/oracles/chrombpnet.py
+++ b/chorus/oracles/chrombpnet.py
@@ -618,16 +618,17 @@ class ChromBPNetOracle(OracleBase):
         else:
             raise ValueError(f"Unsupported sequence type: {type(seq)}")
 
-        # If the caller passes a query wider than the model's input window
-        # (e.g. PR #79's get_max_output_size makes the multi-oracle region
-        # ~1 Mb), the legacy `_predict_direct` sliding formula is buggy and
-        # crashes with an IndexError.  Route wide queries through
-        # `predict_sliding`, which uses the same model.predict_on_batch path
-        # but with correct stitching.  Variant scoring downstream
-        # (`score_region`) still slices the canonical 501 bp window, so
-        # the table values are unchanged.
-        if len(query_interval) > self.sequence_length:
-            return self.predict_sliding(query_interval, assay_ids)
+        # Wide-query handling: queries larger than the model's input window
+        # (e.g. the multi-oracle 1 Mb flow) flow through naturally — the
+        # env-runner template (`chrombpnet_source/templates/predict_template.py`)
+        # has the correct stride-output_length sliding formula and produces
+        # correct (probabilities, counts) for `_transform_predictions_to_tracks`
+        # to stitch.  Direct mode (`use_environment=False`) goes through
+        # `_predict_direct`, which has the same correct formula below.
+        # Callers who want explicit control of the sliding-window batching
+        # (e.g. for cigar-substituted intervals from
+        # `regenerate_multioracle.run_chrombpnet`) can call `predict_sliding`
+        # directly — that path doesn't auto-trigger from here.
 
         input_interval = query_interval.extend(self.sequence_length)
         prediction_interval = query_interval.extend(self.output_size)
@@ -872,10 +873,17 @@ class ChromBPNetOracle(OracleBase):
         MAPPING = {'A': 0, 'C': 1, 'G': 2, 'T': 3}
 
         if len(seq) > self.sequence_length:
+            # Stride-output_length (1000 bp) sliding windows of size
+            # sequence_length (2114 bp).  num_windows is the count we need
+            # to cover the input; seq_len rounds up to fit them exactly.
+            # NOTE: must divide by ``self.output_length``, not
+            # ``self.sequence_length`` — using the latter under-counts and
+            # allocates a too-small `one_hot`, causing IndexError on long
+            # inputs.  Matches the env-runner template
+            # (chrombpnet_source/templates/predict_template.py).
             num_windows_stride_one = (len(seq) - self.sequence_length + 1)
-            num_windows = (num_windows_stride_one + self.sequence_length - 1) // self.sequence_length + 1
+            num_windows = (num_windows_stride_one + self.sequence_length - 1) // self.output_length + 1
 
-            # Define seq_len and flag
             seq_len = (self.output_length * (num_windows - 1)) + self.sequence_length
             trimmed = False
         else:

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="chorus",
-    version="0.5.0",
+    version="0.5.1",
     author="Pinello Lab",
     author_email="lucapinello@gmail.com",
     description="A unified interface for genomic sequence oracles",


### PR DESCRIPTION
Patch release addressing three findings from the ml007 v0.5.0 scorched-earth audit (`audits/2026-05-10_v0.5.0_scorched_earth_linux_cuda/` on ml007's branch).

## P0 — chrombpnet wide-window predict failed in chorus base env

**Symptom**: `oracle.predict(("chrX", 48_730_000, 48_840_000))` from the chorus base env (no TF) crashed with `ModuleNotFoundError: No module named 'tensorflow'`. Two of the three shipped notebooks hit this (advanced_multi_oracle, comprehensive_oracle).

**Root cause**: the auto-route I added in v0.5.0 (`chrombpnet.py:622-630`) forced wide queries through `predict_sliding` → `self.model.predict_on_batch` → direct TF import, bypassing the env-runner subprocess.

**Fix**: drop the auto-route. Wide queries flow naturally through `_predict_in_environment`, whose template (`chrombpnet_source/templates/predict_template.py`) already had the correct stride-`output_length` sliding formula. `predict_sliding` remains as opt-in for direct-mode callers (`use_environment=False`) who want explicit batching control.

**Verification on this Mac**: 110 kb chrombpnet predict (the failing notebook scenario) now returns 110000 bins, max=31.012, 109443 nonzero. ✓

Also fixed the parallel buggy formula in `_predict_direct` (had `// sequence_length` instead of `// output_length`) so direct-mode wide queries work too.

## P1 — alphagenome_pt 404 + misleading "ready" message

**Symptom**: `chorus setup --oracle alphagenome_pt` printed `WARNING: Failed to download alphagenome_pt_pertrack.npz: 404` immediately followed by `✓ alphagenome_pt ready`. Looks half-failed even though behaviour was correct.

**Root cause**: alphagenome_pt aliases to alphagenome's CDFs at lookup time (`PerTrackNormalizer._CDF_ALIASES`), but `download_pertrack_backgrounds` still tried to fetch `alphagenome_pt_pertrack.npz` from HF and logged a 404 warning when it didn't exist.

**Fix**: short-circuit downloads for any oracle in `_CDF_ALIASES`; emit an alias-aware info line instead.

## P2 — `chorus backgrounds status` missing alphagenome_pt

**Symptom**: status table showed only 6 oracles after `chorus setup --oracle all` on v0.5.0.

**Fix**: add `"alphagenome_pt"` to `_KNOWN_ORACLES` (will display as "no backgrounds found", with the alias semantics now documented inline).

## Pre-existing items NOT fixed in this patch

- **alphagenome JAX vs PyTorch backend drift at SORT1** (max abs diff 0.476 on ml007 / 0.996 on this Mac vs PR #62 baseline <0.05). Confirmed pre-existing: `git log v0.4.0..v0.5.0 -- alphagenome*` shows zero changes to alphagenome / alphagenome_pt code in v0.5.0. The drift is likely caused by JAX / torch version drift on Linux/CUDA + macOS Metal vs the pinned versions used at PR #62 baseline. Worth a separate investigation — bisect against PR #62 and check default dtype / device defaults. Tracked as a follow-up.
- **chrombpnet integration test 600s timeout on slow panfs** — env-specific, not a code regression.

## Test plan

- [x] `pytest -m "not integration"` → 375 passed (the 2 alphagenome tests pass with a valid HF token; the backend-equivalence test fails for the pre-existing P0 #1 reason above)
- [x] Reproduce P0 #2 failing scenario, then verify fix
- [x] No regressions on the SORT1 multi-oracle pipeline

🤖 Generated with [Claude Code](https://claude.com/claude-code)