### PR TITLE
v0.5.4 — collaborator round 2 (rsID input, LDlink config, AG example IDs)

### DIFF
--- a/audits/2026-05-13_v0.5.4_collaborator_followups_round2/pytest_log.txt
+++ b/audits/2026-05-13_v0.5.4_collaborator_followups_round2/pytest_log.txt
@@ -1,0 +1,30 @@
+../../.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:88
+../../.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:88
+../../.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:88
+  /Users/lp698/.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:88: PyparsingDeprecationWarning: 'parseString' deprecated - use 'parse_string'
+    parse = parser.parseString(pattern)
+
+../../.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:92
+../../.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:92
+../../.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:92
+../../.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:92
+../../.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:92
+../../.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:92
+  /Users/lp698/.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_fontconfig_pattern.py:92: PyparsingDeprecationWarning: 'resetCache' deprecated - use 'reset_cache'
+    parser.resetCache()
+
+../../.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_mathtext.py:45
+  /Users/lp698/.local/share/mamba/envs/chorus/lib/python3.10/site-packages/matplotlib/_mathtext.py:45: PyparsingDeprecationWarning: 'enablePackrat' deprecated - use 'enable_packrat'
+    ParserElement.enablePackrat()
+
+tests/test_integration.py::test_pertrack_background_download[sei]
+tests/test_integration.py::test_pertrack_background_download[legnet]
+  /Users/lp698/.local/share/mamba/envs/chorus/lib/python3.10/site-packages/huggingface_hub/file_download.py:1842: DeprecationWarning: hf_xet.download_files() is deprecated. Use XetSession().new_file_download_group().start_download_file() instead.
+    xet_get(
+
+tests/test_utils.py::TestNormalizationUtils::test_quantile_normalize
+  /Users/lp698/.local/share/mamba/envs/chorus/lib/python3.10/site-packages/numpy/core/numeric.py:407: RuntimeWarning: invalid value encountered in cast
+    multiarray.copyto(res, fill_value, casting='unsafe')
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+379 passed, 2 skipped, 16 warnings in 769.94s (0:12:49)

--- a/audits/2026-05-13_v0.5.4_collaborator_followups_round2/report.md
+++ b/audits/2026-05-13_v0.5.4_collaborator_followups_round2/report.md
@@ -1,0 +1,61 @@
+# v0.5.4 audit — collaborator-variants round 2
+
+**Date**: 2026-05-13 (verified against chorus v0.5.3 main + survey on 2026-05-12)
+**Branch**: `fix/v0.5.4-collaborator-followups-round2`
+**Tracking issue for item 5 (deferred)**: #83
+
+## Context
+
+A second collaborator (Dmitry Penzar) reproduced an earlier walkthrough (CDYL) and got matching results, then surfaced five issues. Every claim was verified directly against the code before edit. Item 5 (AG normalization over-optimism) is real and substantial — it has been deferred to issue #83 with the full diagnostic + three implementation options for whoever picks it up.
+
+## Verified findings → fix
+
+| # | Claim | Verified | Fix shipped in v0.5.4 |
+|---|---|---|---|
+| **1** | rsID not accepted by `analyze_variant_multilayer` / `discover_variant` / `discover_variant_cell_types` | Partial — only `fine_map_causal_variant` supported it | Added `ldlink_token` + `genome_build` params and an rsID-prefix branch that calls `fetch_ld_variants(r2_threshold=1.1)` (sentinel-only) to resolve coords. `score_variant_batch` intentionally skipped — its variant-dict contract already needs explicit coords (VCF case) |
+| **2** | AG `assay_ids` in 4 walkthrough READMEs use display-name format ("DNASE:HepG2") which raises `ValueError("Assay ID not found in metadata")` at runtime | Verified | Replaced with real identifiers from `metadata.search_tracks()`. Added inline comment showing the lookup. Affected files: `batch_scoring/README.md`, `causal_prioritization/README.md`, `sequence_engineering/README.md`, `variant_analysis/SORT1_rs12740374/multilayer_variant_analysis.md` |
+| **3** | LDlink request timeout (30 s default) hidden from MCP/CLI | Verified | Added `ldlink_timeout: float = 30.0` to `fine_map_causal_variant` MCP signature; threads to `fetch_ld_variants` |
+| **4** | hg38 hardcoded in LDlink calls (`ld.py:101`); also defaulted-but-configurable in `_igv_report.py` and `causal.py` | Partial | Added `genome_build: str = "grch38"` to `fetch_ld_variants` with hg19/grch37/GRCh37/hg38/grch38/GRCh38 aliases; exposed through `fine_map_causal_variant`, `analyze_variant_multilayer`, `discover_variant`, `discover_variant_cell_types` |
+| **5** | AG normalization gives over-optimistic percentiles (even tiny effects → >99th) | **Verified — diagnostic in issue #83** | **Deferred** to issue #83 with the full per-layer percentile-vs-effect-magnitude survey + three implementation options |
+
+## Item 5 diagnosis (full data lives in issue #83)
+
+Direct CDF inspection on the on-disk `~/.chorus/backgrounds/alphagenome_pertrack.npz`:
+
+```
+layer          mean pct at:  0.01    0.05    0.1     0.5     1.0
+ATAC                         0.351   0.896   0.972   0.997   0.999
+DNASE                        0.377   0.884   0.963   0.999   1.000
+CHIP_HISTONE                 0.211   0.720   0.906   0.995   0.998
+CHIP_TF                      0.610   0.894   0.961   0.994   0.998
+RNA_SEQ                      0.999   1.000   1.000   1.000   1.000
+```
+
+Root cause: `scripts/build_backgrounds_alphagenome.py:395-410` samples random genomic positions + random alt alleles. Most random positions hit inactive chromatin → log₂FC clusters near zero → the percentile reflects rarity-vs-noise, not biological importance.
+
+There IS an existing magnitude-based interpretation cap in `variant_report.py::_interpret_score`, but the percentile column and the interpretation column show side-by-side in the report and disagree. The cleanest fix is to suppress percentile below the per-layer magnitude floor (option B in the issue), with option C (rebuild CDF from functional positions) as a follow-up project.
+
+## Files changed
+
+```
+chorus/__init__.py                                                  version bump
+chorus/mcp/server.py                                                #1, #3, #4
+chorus/utils/ld.py                                                  #3, #4
+examples/walkthroughs/batch_scoring/README.md                       #2
+examples/walkthroughs/causal_prioritization/README.md               #2
+examples/walkthroughs/sequence_engineering/README.md                #2
+examples/walkthroughs/variant_analysis/SORT1_rs12740374/multilayer_variant_analysis.md  #2
+setup.py                                                            version bump
+```
+
+## Verification
+
+- ✅ Smoke checks: `ldlink_token` + `genome_build` present on all 4 MCP signatures; `_resolve_rsid_to_position` raises a clear `ValueError` when no LDlink token is available.
+- ✅ Bogus `genome_build` raises `ValueError` with the list of valid aliases.
+- Pytest log: `pytest_log.txt` next to this report.
+
+## Out of scope
+
+- `score_variant_batch` rsID resolution — its variant-dict contract takes `chrom`/`pos`/`ref`/`alt` per row (VCF use case). Adding rsID resolution there would slow down batch jobs and require N LDlink round-trips. Use `fine_map_causal_variant` (which accepts a single rsID) or pre-resolve variants in Python before calling `score_variant_batch`.
+- IGV/causal report `genome` parameter — already configurable via the existing `genome: str = "hg38"` kwarg at `_igv_report.py:327`, just undocumented. README note recommended in a future docs pass.
+- Item 5 — issue #83.

--- a/chorus/__init__.py
+++ b/chorus/__init__.py
@@ -5,7 +5,7 @@ Chorus provides a consistent API for working with various genomic deep learning
 models including Enformer, Borzoi, ChromBPNet, and Sei.
 """
 
-__version__ = "0.5.3"
+__version__ = "0.5.4"
 
 # ---------------------------------------------------------------------------
 # PATH guard for subprocess tools (bgzip, tabix, samtools)

--- a/chorus/mcp/server.py
+++ b/chorus/mcp/server.py
@@ -933,6 +933,8 @@ def analyze_variant_multilayer(
     gene_name: Optional[str] = None,
     region: Optional[str] = None,
     igv_raw: bool = False,
+    ldlink_token: Optional[str] = None,
+    genome_build: str = "grch38",
     user_prompt: Optional[str] = None,
 ) -> dict:
     """Analyze a variant's regulatory impact across all molecular layers.
@@ -955,7 +957,9 @@ def analyze_variant_multilayer(
 
     Args:
         oracle_name: A loaded oracle name.
-        position: Variant position as "chr1:1050000".
+        position: Variant position as ``"chr1:1050000"`` OR an rsID
+                  like ``"rs12740374"`` (requires LDlink token; resolves
+                  to coords via the LDproxy API).
         ref_allele: Reference allele.
         alt_alleles: Alternate alleles.
         assay_ids: List of assay identifiers covering different layers
@@ -968,6 +972,12 @@ def analyze_variant_multilayer(
         igv_raw: When True, the IGV browser in the HTML report shows raw
                  signal with autoscale instead of the layer-aware rescaled
                  view. Table scores are unaffected.
+        ldlink_token: LDlink API token (only used when ``position`` is an
+                  rsID). Register free at https://ldlink.nih.gov/?tab=apiaccess
+                  or set ``LDLINK_TOKEN``.
+        genome_build: Reference build for the rsID lookup
+                  (``"grch38"`` / ``"hg38"`` default; or ``"grch37"`` / ``"hg19"``).
+                  Only used when ``position`` is an rsID.
         user_prompt: The user's original natural-language question. Claude
                      should forward this verbatim whenever calling from an
                      MCP conversation — it is rendered at the top of the
@@ -978,6 +988,13 @@ def analyze_variant_multilayer(
 
     state = _state()
     oracle = state.get_oracle(oracle_name)
+
+    # Resolve an rsID to chr:pos via LDlink before downstream parsing.
+    if position.strip().startswith("rs"):
+        position, _ref_from_ld, _alt_from_ld = _resolve_rsid_to_position(
+            position.strip(), ldlink_token=ldlink_token,
+            genome_build=genome_build,
+        )
 
     if region is None:
         region = _auto_region(oracle, position)
@@ -1033,6 +1050,8 @@ def discover_variant(
     user_prompt: Optional[str] = None,
     ranking_metric: str = "alt_x_abs_effect",
     min_ref_value: float = 0.0,
+    ldlink_token: Optional[str] = None,
+    genome_build: str = "grch38",
 ) -> dict:
     """Discover which cell types and regulatory layers are most affected by a variant.
 
@@ -1046,7 +1065,9 @@ def discover_variant(
 
     Args:
         oracle_name: A loaded oracle name.
-        position: Variant position as "chr1:109274968".
+        position: Variant position as ``"chr1:109274968"`` OR an rsID
+            like ``"rs12740374"`` (requires LDlink token; resolves
+            to coords via the LDproxy API).
         ref_allele: Reference allele (e.g. "G").
         alt_alleles: Alternate alleles (e.g. ["T"]).
         gene_name: Optional gene for expression analysis.
@@ -1058,6 +1079,10 @@ def discover_variant(
             change yields a large fold-change. Use ``"abs_effect"`` for
             the historical raw |log2FC| ranking.
         min_ref_value: Threshold used by ``"abs_effect_min_ref"``.
+        ldlink_token: LDlink API token (only used when ``position`` is
+            an rsID). Register free at https://ldlink.nih.gov/?tab=apiaccess.
+        genome_build: Reference build for the rsID lookup
+            (``"grch38"`` / ``"hg38"`` default; or ``"grch37"`` / ``"hg19"``).
     """
     from chorus.analysis.analysis_request import AnalysisRequest
     from chorus.analysis.discovery import discover_variant_effects
@@ -1065,6 +1090,12 @@ def discover_variant(
     state = _state()
     oracle = state.get_oracle(oracle_name)
     normalizer = state.get_normalizer(oracle_name)
+
+    if position.strip().startswith("rs"):
+        position, _ref_from_ld, _alt_from_ld = _resolve_rsid_to_position(
+            position.strip(), ldlink_token=ldlink_token,
+            genome_build=genome_build,
+        )
 
     result = discover_variant_effects(
         oracle,
@@ -1113,6 +1144,8 @@ def discover_variant_cell_types(
     user_prompt: Optional[str] = None,
     ranking_metric: str = "alt_x_abs_effect",
     min_ref_value: float = 0.0,
+    ldlink_token: Optional[str] = None,
+    genome_build: str = "grch38",
 ) -> dict:
     """Discovery mode: find which cell types are most affected by a variant.
 
@@ -1133,7 +1166,9 @@ def discover_variant_cell_types(
     Args:
         oracle_name: A loaded oracle name (ideally AlphaGenome for broadest
             cell-type coverage).
-        position: Variant position as "chr1:1050000".
+        position: Variant position as ``"chr1:1050000"`` OR an rsID
+            like ``"rs12740374"`` (requires LDlink token; resolves to
+            coords via the LDproxy API).
         ref_allele: Reference allele.
         alt_alleles: Alternate alleles.
         gene_name: Optional gene to focus expression analysis on.
@@ -1152,6 +1187,10 @@ def discover_variant_cell_types(
             to rank by |log2FC| while excluding closed baselines.
         min_ref_value: Threshold for ``"abs_effect_min_ref"`` (ignored
             otherwise). Default 0 = no filter.
+        ldlink_token: LDlink API token (only used when ``position`` is
+            an rsID).
+        genome_build: Reference build for the rsID lookup
+            (``"grch38"`` / ``"hg38"`` default; or ``"grch37"`` / ``"hg19"``).
 
     Returns:
         Dict with:
@@ -1166,6 +1205,12 @@ def discover_variant_cell_types(
 
     state = _state()
     oracle = state.get_oracle(oracle_name)
+
+    if position.strip().startswith("rs"):
+        position, _ref_from_ld, _alt_from_ld = _resolve_rsid_to_position(
+            position.strip(), ldlink_token=ldlink_token,
+            genome_build=genome_build,
+        )
 
     alleles = [ref_allele] + list(alt_alleles)
     result = discover_and_report(
@@ -1427,6 +1472,8 @@ def fine_map_causal_variant(
     population: str = "CEU",
     r2_threshold: float = 0.8,
     ldlink_token: Optional[str] = None,
+    ldlink_timeout: float = 30.0,
+    genome_build: str = "grch38",
     user_prompt: Optional[str] = None,
 ) -> dict:
     """Prioritize causal variants from a GWAS locus using multi-layer regulatory evidence.
@@ -1475,6 +1522,10 @@ def fine_map_causal_variant(
         r2_threshold: Minimum r² for LD variants (default 0.8).
         ldlink_token: LDlink API token. Register free at
             https://ldlink.nih.gov/?tab=apiaccess
+        ldlink_timeout: HTTP timeout in seconds for the LDlink request
+            (default 30). Increase for slow networks or large LD blocks.
+        genome_build: Reference build for the LDlink LD lookup. Accepts
+            ``"grch38"`` / ``"hg38"`` (default) or ``"grch37"`` / ``"hg19"``.
         user_prompt: Original user prompt, rendered at the top of the report.
     """
     from chorus.analysis.causal import prioritize_causal_variants
@@ -1504,6 +1555,8 @@ def fine_map_causal_variant(
                 population=population,
                 r2_threshold=r2_threshold,
                 token=ldlink_token,
+                timeout=ldlink_timeout,
+                genome_build=genome_build,
             )
         except LDLinkError as exc:
             return {"error": str(exc)}
@@ -1549,6 +1602,52 @@ def fine_map_causal_variant(
         except Exception:
             pass
     return output
+
+
+def _resolve_rsid_to_position(
+    rsid: str,
+    ldlink_token: Optional[str] = None,
+    timeout: float = 30.0,
+    genome_build: str = "grch38",
+) -> tuple[str, str, str]:
+    """Resolve an rsID to ``(position_str, ref_allele, alt_allele)`` via LDlink.
+
+    Used by ``analyze_variant_multilayer`` / ``discover_variant`` /
+    ``discover_variant_cell_types`` so that callers can pass an rsID
+    where those tools previously required ``chr:pos``. Hits the LDlink
+    LDproxy API with ``r2_threshold=1.1`` so only the sentinel line is
+    returned (cheap one-record lookup, not a full LD proxy fetch).
+
+    Raises ``ValueError`` on missing alleles or LDlink failure with a
+    fix-it pointer.
+    """
+    from chorus.utils.ld import fetch_ld_variants, LDLinkError
+    try:
+        ld = fetch_ld_variants(
+            rsid,
+            r2_threshold=1.1,  # keep only the sentinel row (always returned)
+            token=ldlink_token,
+            timeout=timeout,
+            genome_build=genome_build,
+        )
+    except LDLinkError as exc:
+        raise ValueError(
+            f"Could not resolve {rsid!r} via LDlink: {exc}. "
+            f"Pass coordinates directly as 'chr1:109274968' if LDlink is "
+            f"unavailable, or set LDLINK_TOKEN."
+        ) from exc
+    if not ld:
+        raise ValueError(
+            f"LDlink returned no record for {rsid!r}. Check that the rsID "
+            f"is valid and present in genome_build={genome_build!r}."
+        )
+    v = ld[0]  # sentinel
+    if not v.ref or not v.alt:
+        raise ValueError(
+            f"LDlink returned {rsid!r} at {v.chrom}:{v.pos} but no alleles. "
+            f"Pass coordinates + alleles directly."
+        )
+    return f"{v.chrom}:{v.pos}", v.ref, v.alt
 
 
 def _parse_lead_variant(text: str) -> dict:

--- a/chorus/utils/ld.py
+++ b/chorus/utils/ld.py
@@ -58,12 +58,23 @@ class LDVariant:
     is_sentinel: bool = False
 
 
+_GENOME_BUILD_ALIASES = {
+    "hg38": "grch38",
+    "GRCh38": "grch38",
+    "grch38": "grch38",
+    "hg19": "grch37",
+    "GRCh37": "grch37",
+    "grch37": "grch37",
+}
+
+
 def fetch_ld_variants(
     variant_id: str,
     population: str = "CEU",
     r2_threshold: float = 0.8,
     token: str | None = None,
     timeout: float = 30.0,
+    genome_build: str = "grch38",
 ) -> list[LDVariant]:
     """Query LDlink LDproxy API and return LD variants above r2 threshold.
 
@@ -74,12 +85,15 @@ def fetch_ld_variants(
         token: LDlink API token. Register free at
             https://ldlink.nih.gov/?tab=apiaccess
         timeout: Request timeout in seconds.
+        genome_build: Reference build for the LDlink query. Accepts
+            ``"grch38"`` / ``"hg38"`` (default) or ``"grch37"`` / ``"hg19"``.
 
     Returns:
         List of LDVariant objects, sentinel first.
 
     Raises:
         LDLinkError: If the API is unavailable or token is missing.
+        ValueError: If ``genome_build`` isn't recognised.
     """
     token = _resolve_ldlink_token(token)
     if token is None:
@@ -90,6 +104,13 @@ def fetch_ld_variants(
             "(c) run 'chorus setup all' to be prompted once."
         )
 
+    if genome_build not in _GENOME_BUILD_ALIASES:
+        raise ValueError(
+            f"Unknown genome_build {genome_build!r}. "
+            f"Choose one of {sorted(set(_GENOME_BUILD_ALIASES))}."
+        )
+    resolved_build = _GENOME_BUILD_ALIASES[genome_build]
+
     import requests
 
     url = "https://ldlink.nih.gov/LDlinkRest/ldproxy"
@@ -98,7 +119,7 @@ def fetch_ld_variants(
         "pop": population,
         "r2_d": "r2",
         "token": token,
-        "genome_build": "grch38",
+        "genome_build": resolved_build,
     }
 
     logger.info("Querying LDlink LDproxy for %s in %s...", variant_id, population)

--- a/examples/walkthroughs/batch_scoring/README.md
+++ b/examples/walkthroughs/batch_scoring/README.md
@@ -61,7 +61,15 @@ score_variant_batch(
         {"chrom": "chr1", "pos": 109278590, "ref": "G", "alt": "A", "id": "rs2228603"},
         {"chrom": "chr1", "pos": 109271200, "ref": "T", "alt": "C", "id": "rs7528419"},
     ],
-    assay_ids=["DNASE:HepG2", "CAGE:HepG2", "H3K27ac:HepG2"],
+    # AlphaGenome track identifiers — find these via
+    # `oracle.metadata.search_tracks("HepG2")` or
+    # `meta.get_tracks_by_description("DNASE:HepG2")` which both return
+    # full identifier strings of the form "OUTPUT_TYPE/<name>/<strand>".
+    assay_ids=[
+        "DNASE/EFO:0001187 DNase-seq/.",                       # DNASE:HepG2
+        "CAGE/hCAGE EFO:0001187/+",                            # CAGE:HepG2 (+ strand)
+        "CHIP_HISTONE/EFO:0001187 Histone ChIP-seq H3K27ac/.", # H3K27ac:HepG2
+    ],
     gene_name="SORT1",
     top_n=20,
 )
@@ -89,9 +97,14 @@ variants = [
     # ...
 ]
 
-# For AlphaGenome, use full track IDs (find them with oracle.search_tracks('HepG2 DNase'))
-result = score_variant_batch(oracle, variants, assay_ids=["DNASE:HepG2"],
-                             oracle_name="alphagenome")  # oracle_name enables percentile normalization
+# For AlphaGenome, pass the full track identifier (look it up with
+# `oracle.metadata.search_tracks("HepG2 DNase")` — the value in the
+# `identifier` column is what `assay_ids=` wants).
+result = score_variant_batch(
+    oracle, variants,
+    assay_ids=["DNASE/EFO:0001187 DNase-seq/."],
+    oracle_name="alphagenome",  # enables percentile normalization
+)
 
 # Output formats
 print(result.to_markdown())                 # Ranked table

--- a/examples/walkthroughs/causal_prioritization/README.md
+++ b/examples/walkthroughs/causal_prioritization/README.md
@@ -101,7 +101,13 @@ fine_map_causal_variant(
          "id": "rs629301", "r2": 0.95},
         # ...more variants...
     ],
-    assay_ids=["DNASE:HepG2", "CAGE:HepG2", "H3K27ac:HepG2"],
+    # AlphaGenome track identifiers (look up via
+    # `oracle.metadata.search_tracks("HepG2")`).
+    assay_ids=[
+        "DNASE/EFO:0001187 DNase-seq/.",                       # DNASE:HepG2
+        "CAGE/hCAGE EFO:0001187/+",                            # CAGE:HepG2 (+ strand)
+        "CHIP_HISTONE/EFO:0001187 Histone ChIP-seq H3K27ac/.", # H3K27ac:HepG2
+    ],
     gene_name="SORT1",
     population="CEU",
     r2_threshold=0.8,

--- a/examples/walkthroughs/sequence_engineering/README.md
+++ b/examples/walkthroughs/sequence_engineering/README.md
@@ -45,7 +45,13 @@ analyze_region_swap(
     oracle_name="alphagenome",
     region="chr1:1000500-1001500",          # region to replace
     replacement_sequence="ACGTACGT...",      # new DNA sequence
-    assay_ids=["DNASE:K562", "CAGE:K562", "H3K27ac:K562"],
+    # AlphaGenome track identifiers — look these up via
+    # `oracle.metadata.search_tracks("K562")` (the `identifier` column).
+    assay_ids=[
+        "DNASE/EFO:0002067 DNase-seq/.",                       # DNASE:K562
+        "CAGE/hCAGE EFO:0002067/+",                            # CAGE:K562 (+ strand)
+        "CHIP_HISTONE/EFO:0002067 Histone ChIP-seq H3K27ac/.", # H3K27ac:K562
+    ],
     gene_name="SORT1",                       # optional
     description="Replace weak promoter with CMV",  # optional
 )
@@ -93,7 +99,13 @@ simulate_integration(
     oracle_name="alphagenome",
     position="chr19:55115000",              # insertion point
     construct_sequence="ACGTACGT...",        # construct DNA
-    assay_ids=["DNASE:K562", "CAGE:K562", "H3K27ac:K562"],
+    # AlphaGenome track identifiers — look these up via
+    # `oracle.metadata.search_tracks("K562")` (the `identifier` column).
+    assay_ids=[
+        "DNASE/EFO:0002067 DNase-seq/.",                       # DNASE:K562
+        "CAGE/hCAGE EFO:0002067/+",                            # CAGE:K562 (+ strand)
+        "CHIP_HISTONE/EFO:0002067 Histone ChIP-seq H3K27ac/.", # H3K27ac:K562
+    ],
     gene_name="PPP1R12C",                   # optional
     description="AAV-GFP at AAVS1",         # optional
 )

--- a/examples/walkthroughs/variant_analysis/SORT1_rs12740374/multilayer_variant_analysis.md
+++ b/examples/walkthroughs/variant_analysis/SORT1_rs12740374/multilayer_variant_analysis.md
@@ -163,7 +163,12 @@ from chorus.analysis import build_variant_report, get_normalizer
 #     genomic_region="chr1:109274968-109274969",
 #     variant_position="chr1:109274968",
 #     alleles=["G", "T"],
-#     assay_ids=["DNASE:HepG2", "CAGE:HepG2", "H3K27ac:HepG2"],
+#     # AlphaGenome track identifiers — see oracle.metadata.search_tracks("HepG2")
+#     assay_ids=[
+#         "DNASE/EFO:0001187 DNase-seq/.",                       # DNASE:HepG2
+#         "CAGE/hCAGE EFO:0001187/+",                            # CAGE:HepG2 (+ strand)
+#         "CHIP_HISTONE/EFO:0001187 Histone ChIP-seq H3K27ac/.", # H3K27ac:HepG2
+#     ],
 # )
 
 # Build report — auto-detects nearby genes for RNA scoring

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="chorus",
-    version="0.5.3",
+    version="0.5.4",
     author="Pinello Lab",
     author_email="lucapinello@gmail.com",
     description="A unified interface for genomic sequence oracles",


### PR DESCRIPTION
## Summary

Five findings from a second collaborator (Dmitry Penzar) on a real GWAS workflow. All verified against the code before edit. **Item 5 (AG normalization over-optimism) is real and substantial** — deferred to issue #83 with full diagnostic + 3 implementation options so it can ship in a focused follow-up.

## What's in v0.5.4

| # | Surface | Change |
|---|---|---|
| **#1** | `chorus/mcp/server.py` + new `_resolve_rsid_to_position` | rsID input now works in `analyze_variant_multilayer`, `discover_variant`, `discover_variant_cell_types`. When `position` starts with `"rs"`, resolves via LDlink (sentinel-only fetch). New `ldlink_token` + `genome_build` params. `score_variant_batch` intentionally skipped — its variant-dict contract takes explicit coords (VCF use case) |
| **#2** | 4 walkthrough READMEs | Replaced display-name `assay_ids` (`"DNASE:HepG2"`) with real AG identifiers (`"DNASE/EFO:0001187 DNase-seq/."`). Added inline comment showing how to look these up via `metadata.search_tracks()` |
| **#3** | `chorus/utils/ld.py` + `chorus/mcp/server.py` | `fine_map_causal_variant` now exposes `ldlink_timeout: float = 30.0` |
| **#4** | `chorus/utils/ld.py` + 4 MCP tools | `fetch_ld_variants` now takes `genome_build` (default `"grch38"`) with `hg19`/`grch37`/`GRCh37`/`hg38`/`grch38`/`GRCh38` aliases. Exposed through all four variant tools (the three new ones use it only for rsID resolution, not for prediction — oracle FASTA controls that) |
| **#5** | issue #83 | **Deferred.** AG percentile is over-optimistic by design: built from random-position random-allele SNPs that mostly hit inactive chromatin. Full diagnostic + 3 fix options in #83 |

## Item 5 — verified diagnosis (not fixed in this PR)

Direct CDF inspection on `~/.chorus/backgrounds/alphagenome_pertrack.npz`:

```
layer          mean pct at:  0.01    0.05    0.1     0.5     1.0
ATAC                         0.351   0.896   0.972   0.997   0.999
DNASE                        0.377   0.884   0.963   0.999   1.000
CHIP_HISTONE                 0.211   0.720   0.906   0.995   0.998
CHIP_TF                      0.610   0.894   0.961   0.994   0.998
RNA_SEQ                      0.999   1.000   1.000   1.000   1.000
```

A log2FC of 0.5 (1.4× fold change) ranks ≥99.7th on ATAC. Root cause: `scripts/build_backgrounds_alphagenome.py:395-410` samples random genomic positions + random alt alleles. The magnitude-based interpretation cap in `_interpret_score` is correct ("Minimal effect" for raw < 0.1), but it shows side-by-side with `≥99th percentile` which is what catches the user's eye. Three options in #83.

## Verification

- ✅ Smoke checks: `ldlink_token` + `genome_build` present on all 4 MCP signatures; `_resolve_rsid_to_position` raises a clear `ValueError` when no LDlink token; bogus `genome_build` raises with the list of valid aliases.
- ✅ Chorus base test suite: **379 passed, 2 skipped, 0 failed** (12:49) — see `audits/2026-05-13_v0.5.4_collaborator_followups_round2/pytest_log.txt`.

## Test plan
- [ ] Reviewer eyeballs the audit report
- [ ] Reviewer reads issue #83 and decides whether the deferral scope is right
- [ ] On approval: merge → tag v0.5.4 → GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)