### PR TITLE
v0.5.5 — indel + multi-allelic variant prioritization

### DIFF
--- a/audits/2026-05-13_v0.5.5_indel_variant_prioritization/pytest_log.txt
+++ b/audits/2026-05-13_v0.5.5_indel_variant_prioritization/pytest_log.txt
@@ -1,0 +1,5 @@
+  /Users/lp698/.local/share/mamba/envs/chorus/lib/python3.10/site-packages/numpy/core/numeric.py:407: RuntimeWarning: invalid value encountered in cast
+    multiarray.copyto(res, fill_value, casting='unsafe')
+
+-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+389 passed, 2 skipped, 16 warnings in 799.64s (0:13:19)

--- a/audits/2026-05-13_v0.5.5_indel_variant_prioritization/report.md
+++ b/audits/2026-05-13_v0.5.5_indel_variant_prioritization/report.md
@@ -1,0 +1,95 @@
+# v0.5.5 — Indel + multi-allelic variant prioritization
+
+**Date**: 2026-05-13
+**Branch**: `fix/v0.5.5-indel-variant-prioritization`
+**Trigger**: collaborator report on chr6 GWAS workflow where indel and
+multi-allelic LD proxies were silently dropped or rejected.
+
+## Context
+
+`predict_variant_effect` hard-rejected any allele with `len != 1` at
+`chorus/core/base.py:415-424` (`InvalidRegionError("…single-nucleotide
+variant…")`). The downstream machinery — `apply_variant`,
+`Interval.replace`, and `parse_ld_response` — already supported indels
+in principle: they just never saw them because the gate fired first.
+
+The collaborator's chr6 examples that v0.5.4 silently dropped:
+
+```
+rs869216555   chr6:4570564   (GAAAAAATAAAAA/-)   13-bp deletion
+rs1418831098  chr6:4573808   (A/-)               1-bp deletion
+rs150831380   chr6:4594841   (-/CT)              2-bp insertion
+.             chr6:4581552   (CT/-)              2-bp deletion
+```
+
+Plus multi-allelic rows with `Correlated_Alleles="T=CT,A=-"` (two
+sentinel↔proxy mappings per row, of which only the first was parsed).
+
+## What v0.5.5 ships
+
+| Surface | Change |
+|---|---|
+| `chorus/utils/sequence.py` (new) | `normalize_allele(a)` accepts LDlink `"-"` and `None`, uppercases, validates ACGTN. `classify_variant(ref, alt)` → `snv` / `insertion` / `deletion` / `mnv` / `complex` |
+| `chorus/core/base.py` `predict_variant_effect` | SNV-only validator replaced. Now accepts any `(ref, alt)` over normalized ACGTN bases, including empty strings. Auto-widens `region_interval` if user's region is narrower than `len(ref)`. Multi-base ref comparison + multi-base replace |
+| `chorus/utils/sequence.py` `get_centered_window` | Equal-length restriction lifted. For deletions, pulls extra flanking on the right to keep `len(alt_seq) == length`. For insertions, trims the right flank. Variant anchored at `length // 2` in both returned sequences |
+| `chorus/utils/ld.py` `parse_ld_response` | New `_extract_allele_pairs` helper. Priority: (1) `Correlated_Alleles` `SENT=PROXY,SENT=PROXY` → one LDVariant per pair with `(ref=SENT, alt=PROXY)`; (2) comma-split `Alleles` `(REF/ALT1,ALT2)` → one LDVariant per alt; (3) single `(REF/ALT)`. All alleles routed through `normalize_allele`. New `LDVariant.kind` field |
+| `chorus/utils/ld.py` `fetch_ld_variants` | New `snvs_only: bool = False` filter |
+| `chorus/analysis/causal.py` `prioritize_causal_variants` | New `snvs_only: bool = False` filter. `CausalVariantScore.kind` field surfaced in `to_dict` + markdown report `[(deletion)]` style suffix |
+| `chorus/mcp/server.py` `fine_map_causal_variant` | New `snvs_only: bool = False` parameter, threaded through to both `fetch_ld_variants` and `prioritize_causal_variants`. Docstring notes that indels are now scored by default |
+| Tests | `test_indel_rejected_before_model_run` → `test_indel_accepted_and_scored` (4 indel cases). New `test_predict_variant_effect_rejects_garbage_allele` keeps the validator honest. New: `test_normalize_allele_table`, `test_classify_variant`, `test_get_centered_window_indels`, `test_parse_ld_response_dash_indel`, `test_parse_ld_response_multi_allelic_alt`, `test_parse_ld_response_correlated_alleles_fanout`, `test_fetch_ld_variants_snvs_only_filter`, `test_prioritize_causal_variants_indels`, `test_prioritize_causal_variants_snvs_only` |
+
+## Scope decisions (per user clarification on 2026-05-13)
+
+- **Correlated_Alleles fanout = two variants per row.** Each
+  `SENT=PROXY` pair is treated as an independent mutation to score
+  (so a row with `T=CT,A=-` emits both `(T → CT)` and `(A → "")`).
+  Fallback to `Alleles` column when `Correlated_Alleles` is `NA` /
+  missing.
+- **`-` accepted everywhere.** `normalize_allele` runs at every
+  entry point. Users can pass `"-"` as ref or alt to any public API.
+- **`snvs_only=False` is the default.** The new behaviour ships
+  enabled. Callers reproducing the pre-v0.5.5 SNV-only flow should
+  pass `snvs_only=True`.
+
+## Backward-compat note
+
+This release relaxes a long-standing validation contract. Callers
+that depended on `InvalidRegionError("…single-nucleotide variant…")`
+to filter out indels will now have those variants pass through and be
+scored. Migration: pass `snvs_only=True` to `fine_map_causal_variant`
+/ `prioritize_causal_variants` / `fetch_ld_variants` to restore the
+old behaviour.
+
+The `test_indel_rejected_before_model_run` test is flipped to
+`test_indel_accepted_and_scored`. Any downstream code that imports
+chorus internals and asserts on rejection will need updating.
+
+## Verification
+
+- ✅ Targeted unit tests: 9 new + 5 existing all pass.
+- ✅ Smoke checks:
+  - `normalize_allele('-') == ''`, rejects `'X'`, `'AT?'`
+  - `classify_variant('A','')` → `'deletion'`; `('A','AT')` → `'complex'`
+  - `get_centered_window` returns `length`-bp ref + alt for SNV, insertion (`-/AT`), deletion (`G/-`), MNV, anchored insertion (`G/GAT`)
+  - `parse_ld_response` fans out `Correlated_Alleles="T=CT,A=-"` into two records
+  - `prioritize_causal_variants(snvs_only=True)` drops indels before scoring
+- Full base regression: see `pytest_log.txt` next to this report.
+
+## Out of scope
+
+- **Large structural variants (>50 bp).** AG's 1 MB input window
+  fits them but scoring quality is uncalibrated; the per-track CDFs
+  were built from SNVs.
+- **VCF normalisation / allele left-shifting.** Chorus accepts
+  whatever the caller passes verbatim. Users wanting `bcftools norm`
+  semantics should run that first.
+- **`score_variant_batch` indel test.** Its variant-dict contract
+  already accepts arbitrary `(ref, alt)`; once `predict_variant_effect`
+  accepts indels (this release), it flows through. Add a regression
+  test in a follow-up release.
+- **Track-output array alignment around the indel.** A 13-bp
+  deletion shifts genomic positions downstream by 13 bp in the alt
+  sequence; the model's bin-i output for the alt corresponds to a
+  shifted genome position. Windowed-sum scoring is robust to small
+  shifts, but exact-position track-rendering inside the indel is
+  off by `delta` bp. Acknowledged limitation; documenting only.

--- a/chorus/__init__.py
+++ b/chorus/__init__.py
@@ -5,7 +5,7 @@ Chorus provides a consistent API for working with various genomic deep learning
 models including Enformer, Borzoi, ChromBPNet, and Sei.
 """
 
-__version__ = "0.5.4"
+__version__ = "0.5.5"
 
 # ---------------------------------------------------------------------------
 # PATH guard for subprocess tools (bgzip, tabix, samtools)

--- a/chorus/analysis/causal.py
+++ b/chorus/analysis/causal.py
@@ -64,6 +64,11 @@ class CausalVariantScore:
     # Composite
     composite: float
 
+    # "snv" | "insertion" | "deletion" | "mnv" | "complex" — derived from
+    # ref/alt at score time. Defaults to "snv" for backwards compatibility
+    # with code that builds CausalVariantScore by hand.
+    kind: str = "snv"
+
     # Per-layer breakdown
     per_layer_scores: dict = field(default_factory=dict)
     per_layer_directions: dict = field(default_factory=dict)
@@ -122,6 +127,7 @@ class CausalResult:
                 "position": s.position,
                 "ref": s.ref,
                 "alt": s.alt,
+                "kind": getattr(s, "kind", "snv"),
                 "r2": s.r2,
                 "is_sentinel": s.is_sentinel,
                 "gene_name": s.gene_name,
@@ -169,6 +175,7 @@ class CausalResult:
                     "position": s.position,
                     "ref": s.ref,
                     "alt": s.alt,
+                    "kind": getattr(s, "kind", "snv"),
                     "r2": s.r2,
                     "is_sentinel": s.is_sentinel,
                     "gene_name": s.gene_name,
@@ -279,9 +286,10 @@ class CausalResult:
                 "|------|---------|-----|-----------|--------|-------------|-----------|"]
         for i, s in enumerate(self.scores, 1):
             mark = " ★" if s.is_sentinel else ""
+            kind_suffix = "" if getattr(s, "kind", "snv") == "snv" else f" ({s.kind})"
             sign = "+" if s.max_effect >= 0 else ""
             rows.append(
-                f"| {i} | {s.variant_id}{mark} | {s.r2:.2f} "
+                f"| {i} | {s.variant_id}{mark}{kind_suffix} | {s.r2:.2f} "
                 f"| {sign}{s.max_effect:.3f} | {s.n_layers_affected} "
                 f"| {s.convergence_score:.2f} | {s.composite:.3f} |"
             )
@@ -314,7 +322,8 @@ class CausalResult:
         rows = [header, sep]
         for i, s in enumerate(self.scores, 1):
             mark = " ★" if s.is_sentinel else ""
-            row = f"| {i} | {s.variant_id}{mark} | {s.r2:.2f} |"
+            kind_suffix = "" if getattr(s, "kind", "snv") == "snv" else f" ({s.kind})"
+            row = f"| {i} | {s.variant_id}{mark}{kind_suffix} | {s.r2:.2f} |"
             for tid in col_order:
                 ts = s.track_scores.get(tid)
                 if ts and ts.raw_score is not None:
@@ -349,6 +358,7 @@ def prioritize_causal_variants(
     weights: CausalWeights | None = None,
     normalizer: QuantileNormalizer | None = None,
     analysis_request: AnalysisRequest | None = None,
+    snvs_only: bool = False,
 ) -> CausalResult:
     """Score and rank LD variants by composite causal evidence.
 
@@ -369,6 +379,10 @@ def prioritize_causal_variants(
         normalizer: Optional quantile normalizer.
         analysis_request: Optional :class:`AnalysisRequest` with the user's
             prompt; rendered at the top of the report for traceability.
+        snvs_only: When True, skip LDVariants with ``kind != "snv"``
+            (insertions, deletions, MNVs, complex multi-base changes).
+            Default False — score every proxy regardless of variant
+            type. Set True to reproduce the pre-v0.5.5 behavior.
 
     Returns:
         :class:`CausalResult` with variants ranked by composite score.
@@ -384,6 +398,16 @@ def prioritize_causal_variants(
         oracle_name = getattr(oracle, "name", None) or oracle.__class__.__name__.lower()
 
     sentinel_id = lead_variant.get("id", f"{lead_variant['chrom']}:{lead_variant['pos']}")
+
+    if snvs_only:
+        n_before = len(ld_variants)
+        ld_variants = [v for v in ld_variants if getattr(v, "kind", "snv") == "snv"]
+        dropped = n_before - len(ld_variants)
+        if dropped:
+            logger.info(
+                "snvs_only=True dropped %d non-SNV proxies (kept %d)",
+                dropped, len(ld_variants),
+            )
 
     # Score each variant
     raw_scores: list[CausalVariantScore] = []
@@ -446,6 +470,7 @@ def prioritize_causal_variants(
                 alt=ldv.alt,
                 r2=ldv.r2,
                 is_sentinel=ldv.is_sentinel,
+                kind=getattr(ldv, "kind", "snv"),
                 max_effect=0.0,
                 n_layers_affected=0,
                 convergence_score=0.0,
@@ -585,6 +610,7 @@ def _extract_component_scores(
         alt=ldv.alt,
         r2=ldv.r2,
         is_sentinel=ldv.is_sentinel,
+        kind=getattr(ldv, "kind", "snv"),
         max_effect=max_effect,
         n_layers_affected=n_layers,
         convergence_score=convergence,

--- a/chorus/core/base.py
+++ b/chorus/core/base.py
@@ -392,11 +392,6 @@ class OracleBase(ABC):
         region_start_0based = region_start - 1  # 1-based inclusive → 0-based
         var_pos_0based = var_pos - 1            # 1-based → 0-based
 
-        region_interval = Interval.make(GenomeRef(chrom=region_chrom,
-                                                  start=region_start_0based,
-                                                  end=region_end,
-                                                  fasta=genome))
-
         # Parse alleles
         if isinstance(alleles, pd.DataFrame):
             ref_allele = alleles.iloc[0]['ref']
@@ -405,39 +400,72 @@ class OracleBase(ABC):
             ref_allele = alleles[0]
             alt_alleles = alleles[1:]
 
-        # SNV-only validation. `predict_variant_effect` substitutes a
-        # single base at `real_pos` (see lines ~342 / ~347 below), so an
-        # indel (ref='G' / alt='GT' or ref='GT' / alt='G') would silently
-        # be treated as a 1-base swap — giving a semantically nonsense
-        # score. Reject up-front with a clear message naming the bad
-        # allele, so the user doesn't waste an oracle run on invalid
-        # input (v20 §14.2 finding).
-        all_alleles = [ref_allele, *alt_alleles]
-        for a in all_alleles:
-            if not isinstance(a, str) or len(a) != 1 or a.upper() not in "ACGTN":
-                raise InvalidRegionError(
-                    f"Allele {a!r} is not a single-nucleotide variant. "
-                    f"predict_variant_effect currently supports SNVs only "
-                    f"(ref/alt each one of A, C, G, T, N). For indels or "
-                    f"multi-base substitutions, use predict_region_replacement "
-                    f"with explicit genomic_region + seq."
-                )
+        # Normalize alleles up-front: accept LDlink ``"-"`` notation,
+        # uppercase, and validate ACGTN. ``normalize_allele`` raises
+        # ``InvalidRegionError`` on anything else (a base like "X", an
+        # un-normalised dash inside a longer allele like ``"AT-"``, etc.).
+        from ..utils.sequence import normalize_allele
+        ref_allele = normalize_allele(ref_allele)
+        alt_alleles = [normalize_allele(a) for a in alt_alleles]
+        if not alt_alleles:
+            raise InvalidRegionError(
+                "At least one alt allele is required (alleles list must have "
+                "ref + ≥1 alt)."
+            )
+        if ref_allele == "" and all(a == "" for a in alt_alleles):
+            raise InvalidRegionError(
+                "Both ref and alt alleles are empty after normalization — "
+                "nothing to score."
+            )
+
+        # Auto-widen the genomic_region if the user-provided window is
+        # narrower than the ref allele. Common when MCP callers pass a
+        # 1-bp region for an indel; we silently widen here so callers
+        # don't have to know how many bases the ref spans.
+        ref_len = len(ref_allele)
+        ref_end_0based = var_pos_0based + max(1, ref_len)
+        if ref_end_0based > region_end:
+            region_end = ref_end_0based
+
+        region_interval = Interval.make(GenomeRef(chrom=region_chrom,
+                                                  start=region_start_0based,
+                                                  end=region_end,
+                                                  fasta=genome))
 
         intervals = {}
         real_pos = region_interval.ref2query(var_pos_0based, ref_global=True)
-        # Case-insensitive compare: pyfaidx returns lowercase for softmasked
-        # (repetitive) regions, users always pass uppercase.
-        if region_interval[real_pos].upper() != ref_allele.upper():
+
+        # Determine the slice of the reference interval that the ref
+        # allele claims to cover. For a pure insertion (ref==""), this
+        # slice has length 0 and there is nothing to validate against
+        # the genome.
+        ref_genome_seq = ""
+        if ref_len > 0:
+            ref_genome_seq = region_interval[real_pos:real_pos + ref_len].sequence.upper()
+
+        # Case-insensitive compare; pyfaidx returns lowercase for
+        # softmasked regions, callers always pass uppercase.
+        if ref_len > 0 and ref_genome_seq != ref_allele:
             logger.warning(
-                'Provided reference allele %r does not match the genome at this position (%r). Chorus will use the provided allele.',
-                ref_allele, region_interval[real_pos],
+                "Provided reference allele %r does not match the genome at "
+                "%s:%d (genome=%r). Chorus will substitute the provided "
+                "reference allele into the prediction interval — verify "
+                "your coordinates and genome build.",
+                ref_allele, region_chrom, var_pos, ref_genome_seq,
             )
-            intervals['reference'] = region_interval.replace(seq=ref_allele, start=real_pos, end=real_pos+1)
+            intervals['reference'] = region_interval.replace(
+                seq=ref_allele, start=real_pos, end=real_pos + ref_len,
+            )
         else:
             intervals['reference'] = region_interval
-        
+
         for i, alt in enumerate(alt_alleles):
-            intervals[f'alt_{i+1}'] = region_interval.replace(seq=alt, start=real_pos, end=real_pos+1)
+            # Pure insertion: end == start, replace inserts at the
+            # position without deleting anything. Pure deletion:
+            # alt == "", replace deletes ref_len bases without inserting.
+            intervals[f'alt_{i+1}'] = region_interval.replace(
+                seq=alt, start=real_pos, end=real_pos + ref_len,
+            )
 
         
         # Get predictions for each sequence

--- a/chorus/mcp/server.py
+++ b/chorus/mcp/server.py
@@ -1474,6 +1474,7 @@ def fine_map_causal_variant(
     ldlink_token: Optional[str] = None,
     ldlink_timeout: float = 30.0,
     genome_build: str = "grch38",
+    snvs_only: bool = False,
     user_prompt: Optional[str] = None,
 ) -> dict:
     """Prioritize causal variants from a GWAS locus using multi-layer regulatory evidence.
@@ -1526,6 +1527,11 @@ def fine_map_causal_variant(
             (default 30). Increase for slow networks or large LD blocks.
         genome_build: Reference build for the LDlink LD lookup. Accepts
             ``"grch38"`` / ``"hg38"`` (default) or ``"grch37"`` / ``"hg19"``.
+        snvs_only: When True, restrict scoring to single-nucleotide
+            substitutions (drops insertions, deletions, MNVs, and
+            complex multi-base proxies). Default False — indels and
+            multi-allelic LDlink rows are scored by default as of
+            v0.5.5. Set True to reproduce pre-v0.5.5 behavior.
         user_prompt: Original user prompt, rendered at the top of the report.
     """
     from chorus.analysis.causal import prioritize_causal_variants
@@ -1557,6 +1563,7 @@ def fine_map_causal_variant(
                 token=ldlink_token,
                 timeout=ldlink_timeout,
                 genome_build=genome_build,
+                snvs_only=snvs_only,
             )
         except LDLinkError as exc:
             return {"error": str(exc)}
@@ -1590,6 +1597,7 @@ def fine_map_causal_variant(
         oracle_name=oracle_name,
         normalizer=state.get_normalizer(oracle_name),
         analysis_request=ar,
+        snvs_only=snvs_only,
     )
 
     output = result.to_dict()

--- a/chorus/utils/__init__.py
+++ b/chorus/utils/__init__.py
@@ -10,6 +10,8 @@ from .sequence import (
     split_sequence_into_windows,
     pad_sequence,
     get_centered_window,
+    normalize_allele,
+    classify_variant,
 )
 
 from .normalization import (
@@ -57,6 +59,8 @@ __all__ = [
     'split_sequence_into_windows',
     'pad_sequence',
     'get_centered_window',
+    'normalize_allele',
+    'classify_variant',
     
     # Normalization utilities
     'normalize_tracks',

--- a/chorus/utils/ld.py
+++ b/chorus/utils/ld.py
@@ -45,7 +45,14 @@ class LDLinkError(Exception):
 
 @dataclass
 class LDVariant:
-    """A variant in linkage disequilibrium with a sentinel."""
+    """A variant in linkage disequilibrium with a sentinel.
+
+    ``ref``/``alt`` are stored after normalization: LDlink ``"-"`` is
+    converted to ``""`` (empty string) for insertions/deletions. The
+    ``kind`` field classifies the variant for downstream filtering
+    (e.g. the ``snvs_only`` switch on ``fetch_ld_variants`` /
+    ``prioritize_causal_variants``).
+    """
 
     variant_id: str
     chrom: str
@@ -56,6 +63,7 @@ class LDVariant:
     dprime: float = 1.0
     distance: int = 0
     is_sentinel: bool = False
+    kind: str = "snv"  # "snv" | "insertion" | "deletion" | "mnv" | "complex"
 
 
 _GENOME_BUILD_ALIASES = {
@@ -75,6 +83,7 @@ def fetch_ld_variants(
     token: str | None = None,
     timeout: float = 30.0,
     genome_build: str = "grch38",
+    snvs_only: bool = False,
 ) -> list[LDVariant]:
     """Query LDlink LDproxy API and return LD variants above r2 threshold.
 
@@ -87,6 +96,10 @@ def fetch_ld_variants(
         timeout: Request timeout in seconds.
         genome_build: Reference build for the LDlink query. Accepts
             ``"grch38"`` / ``"hg38"`` (default) or ``"grch37"`` / ``"hg19"``.
+        snvs_only: When True, drop any returned LDVariant whose
+            ``kind`` is not ``"snv"`` (i.e. exclude insertions,
+            deletions, MNVs, and complex multi-base changes). Default
+            False — score every proxy regardless of variant type.
 
     Returns:
         List of LDVariant objects, sentinel first.
@@ -135,8 +148,86 @@ def fetch_ld_variants(
         raise LDLinkError(f"LDlink API error: {text.strip()}")
 
     variants = parse_ld_response(text, r2_threshold=r2_threshold)
+    if snvs_only:
+        n_before = len(variants)
+        variants = [v for v in variants if v.kind == "snv"]
+        n_dropped = n_before - len(variants)
+        if n_dropped:
+            logger.info("snvs_only filter dropped %d non-SNV proxies", n_dropped)
     logger.info("Found %d variants in LD (r² >= %.2f)", len(variants), r2_threshold)
     return variants
+
+
+def _extract_allele_pairs(
+    alleles_field: str,
+    correlated_field: str | None,
+) -> list[tuple[str, str]]:
+    """Return a list of ``(ref, alt)`` pairs for an LDlink row.
+
+    Three sources are tried in order:
+
+    1. ``Correlated_Alleles`` of shape ``"SENT=PROXY,SENT=PROXY"``
+       (the LDlink LDproxy column showing sentinel↔proxy allele
+       co-segregation). When both pairs have non-empty alleles after
+       normalisation, emit **two** ``(SENT, PROXY)`` records so the
+       prioritization function can score each haplotype-specific
+       transition independently.
+    2. ``Alleles`` of shape ``"(REF/ALT1,ALT2,...)"`` — comma-split the
+       alt half and emit one record per alt.
+    3. ``Alleles`` of shape ``"(REF/ALT)"`` — a single record.
+
+    Empty / ``"-"`` alleles are normalised via
+    :func:`chorus.utils.sequence.normalize_allele` (LDlink uses ``"-"``
+    for indels; chorus internally uses ``""``). Rows that fail to
+    produce any valid (ref, alt) pair return an empty list and the
+    caller should skip them.
+    """
+    from .sequence import normalize_allele
+    from ..core.exceptions import InvalidRegionError
+
+    # 1) Correlated_Alleles fanout
+    if correlated_field and correlated_field.strip() not in ("", "NA", "."):
+        pairs_out: list[tuple[str, str]] = []
+        for entry in correlated_field.split(","):
+            entry = entry.strip()
+            if "=" not in entry:
+                pairs_out = []
+                break
+            sent_raw, prox_raw = entry.split("=", 1)
+            try:
+                sent = normalize_allele(sent_raw)
+                prox = normalize_allele(prox_raw)
+            except InvalidRegionError:
+                pairs_out = []
+                break
+            # Both ref (sentinel allele) and alt (proxy allele) being
+            # empty would mean "no change" — skip.
+            if sent == "" and prox == "":
+                continue
+            pairs_out.append((sent, prox))
+        if pairs_out:
+            return pairs_out
+
+    # 2/3) Alleles column (with comma-split fallback for multi-allelic alt)
+    allele_str = alleles_field.strip().strip("()")
+    if "/" not in allele_str:
+        return []
+    ref_raw, alt_raw = allele_str.split("/", 1)
+    try:
+        ref = normalize_allele(ref_raw)
+    except InvalidRegionError:
+        return []
+
+    pairs_out = []
+    for alt_raw_one in alt_raw.split(","):
+        try:
+            alt = normalize_allele(alt_raw_one)
+        except InvalidRegionError:
+            continue
+        if ref == "" and alt == "":
+            continue
+        pairs_out.append((ref, alt))
+    return pairs_out
 
 
 def parse_ld_response(
@@ -145,6 +236,10 @@ def parse_ld_response(
 ) -> list[LDVariant]:
     """Parse tab-separated LDlink LDproxy response text.
 
+    Indels are returned with empty-string alleles (LDlink's ``"-"`` is
+    normalised). Multi-allelic rows fan out into multiple
+    :class:`LDVariant` entries — see :func:`_extract_allele_pairs`.
+
     Args:
         text: Raw TSV response from LDproxy API.
         r2_threshold: Minimum r² to include.
@@ -152,6 +247,8 @@ def parse_ld_response(
     Returns:
         List of LDVariant objects, sentinel first.
     """
+    from .sequence import classify_variant
+
     lines = text.strip().split("\n")
     if len(lines) < 2:
         return []
@@ -167,6 +264,10 @@ def parse_ld_response(
     dist_col = col_map.get("Distance", col_map.get("distance", 4))
     dprime_col = col_map.get("Dprime", col_map.get("dprime", 5))
     r2_col = col_map.get("R2", col_map.get("r2", 6))
+    correlated_col = col_map.get(
+        "Correlated_Alleles",
+        col_map.get("correlated_alleles", None),
+    )
 
     variants: list[LDVariant] = []
 
@@ -197,11 +298,16 @@ def parse_ld_response(
         if not chrom.startswith("chr"):
             chrom = f"chr{chrom}"
 
-        # Parse alleles: "(G/T)" or "G/T"
-        alleles_str = fields[alleles_col].strip().strip("()")
-        allele_parts = alleles_str.split("/")
-        ref = allele_parts[0] if len(allele_parts) >= 1 else ""
-        alt = allele_parts[1] if len(allele_parts) >= 2 else ""
+        correlated_raw = (
+            fields[correlated_col].strip()
+            if correlated_col is not None and correlated_col < len(fields)
+            else None
+        )
+        allele_pairs = _extract_allele_pairs(
+            fields[alleles_col], correlated_raw,
+        )
+        if not allele_pairs:
+            continue
 
         # Parse other fields
         rs_id = fields[rs_col].strip()
@@ -214,17 +320,19 @@ def parse_ld_response(
         except (ValueError, IndexError):
             distance = 0
 
-        variants.append(LDVariant(
-            variant_id=rs_id if rs_id and rs_id != "." else f"{chrom}:{position}",
-            chrom=chrom,
-            position=position,
-            ref=ref,
-            alt=alt,
-            r2=r2_val,
-            dprime=dprime,
-            distance=distance,
-            is_sentinel=(i == 0),
-        ))
+        for ref, alt in allele_pairs:
+            variants.append(LDVariant(
+                variant_id=rs_id if rs_id and rs_id != "." else f"{chrom}:{position}",
+                chrom=chrom,
+                position=position,
+                ref=ref,
+                alt=alt,
+                r2=r2_val,
+                dprime=dprime,
+                distance=distance,
+                is_sentinel=(i == 0),
+                kind=classify_variant(ref, alt),
+            ))
 
     return variants
 

--- a/chorus/utils/sequence.py
+++ b/chorus/utils/sequence.py
@@ -1,10 +1,76 @@
 """Sequence manipulation utilities."""
 
 import pysam
-from typing import Tuple, Optional, List
+from typing import Tuple, Optional, List, Literal
 import pandas as pd
 import re
 from ..core.exceptions import InvalidRegionError, FileFormatError
+
+
+_VALID_BASES = frozenset("ACGTN")
+
+
+def normalize_allele(a: object) -> str:
+    """Normalize a single allele string to a canonical empty/ACGTN form.
+
+    Accepts the LDlink-style ``"-"`` deletion notation and ``None`` and
+    returns the empty string. Strips whitespace, uppercases, and
+    validates that the remaining characters are all ``A``/``C``/``G``/
+    ``T``/``N``. Raises ``InvalidRegionError`` on anything else.
+
+    Examples
+    --------
+    >>> normalize_allele("-")
+    ''
+    >>> normalize_allele("a")
+    'A'
+    >>> normalize_allele(" CT ")
+    'CT'
+    >>> normalize_allele(None)
+    ''
+    """
+    if a is None:
+        return ""
+    if not isinstance(a, str):
+        raise InvalidRegionError(
+            f"Allele must be a string (or None / '-'); got {type(a).__name__}: {a!r}"
+        )
+    s = a.strip()
+    if s in ("", "-"):
+        return ""
+    s = s.upper()
+    bad = [c for c in s if c not in _VALID_BASES]
+    if bad:
+        raise InvalidRegionError(
+            f"Allele {a!r} contains non-ACGTN characters: {''.join(sorted(set(bad)))}. "
+            f"Use '-' or '' for indels; ACGTN bases otherwise."
+        )
+    return s
+
+
+def classify_variant(
+    ref: str, alt: str,
+) -> Literal["snv", "insertion", "deletion", "mnv", "complex"]:
+    """Classify a (ref, alt) pair after :func:`normalize_allele`.
+
+    - ``"snv"``: 1-bp substitution (``len(ref) == len(alt) == 1``)
+    - ``"insertion"``: ``ref == ""``, alt non-empty
+    - ``"deletion"``: alt ``== ""``, ref non-empty
+    - ``"mnv"``: same-length multi-base substitution (``len > 1``)
+    - ``"complex"``: anything else (different non-zero lengths, VCF-style
+      anchored indels like ``A`` → ``AT``)
+    """
+    if ref == "" and alt == "":
+        return "complex"
+    if ref == "":
+        return "insertion"
+    if alt == "":
+        return "deletion"
+    if len(ref) == len(alt) == 1:
+        return "snv"
+    if len(ref) == len(alt):
+        return "mnv"
+    return "complex"
 
 
 def extract_sequence(
@@ -377,60 +443,97 @@ def get_centered_window(
     helper handles the conversion in one place to avoid the off-by-one
     bugs that plagued hand-rolled variant-sweep scripts.
 
+    Supports SNVs, MNVs, insertions, deletions, and VCF-style anchored
+    indels. ``ref`` and ``alt`` may differ in length; ``"-"`` (LDlink
+    notation) and ``""`` both mean "no bases on this side". The
+    variant starts at position ``length // 2`` in both returned
+    sequences. ``alt_seq`` is always exactly ``length`` bp — for a
+    deletion, extra genomic flank is fetched on the right to fill the
+    window; for an insertion, the right flank is trimmed.
+
     Args:
         fasta_path: Path to indexed reference FASTA.
         chrom: Chromosome name (e.g. ``"chr1"``).
         pos_1based: 1-based variant position (as reported by dbSNP / gnomAD).
+            For pure insertions this is the position of the base
+            *immediately to the right of* the insertion (matches LDlink).
         length: Desired output length (e.g. 2114 for ChromBPNet).
-        ref: Reference allele (single base supported; longer is allowed
-             provided ``len(ref) == len(alt)`` for an in-place SNV/MNV).
-        alt: Alternate allele.
+        ref: Reference allele. Single base, multi-base (MNV), or
+            empty (``""`` / ``"-"`` for pure insertion).
+        alt: Alternate allele. Single base, multi-base, or empty
+            (``""`` / ``"-"`` for pure deletion).
         strict: If True (default) raise ``ValueError`` on reference-allele
-                mismatch. If False, log a warning and return the
-                FASTA-true sequence as ``ref_seq``.
+                mismatch against the FASTA. If False, log a warning
+                and return the FASTA-true sequence as ``ref_seq``.
 
     Returns:
         ``(ref_seq, alt_seq)``, each of length ``length``, both upper-case.
-        The variant is positioned at the centre of the window.
 
     Raises:
-        ValueError: when ``strict=True`` and the FASTA base at
-            ``pos_1based`` does not match ``ref``.
+        ValueError: when ``strict=True`` and the FASTA bases at
+            ``pos_1based:pos_1based+len(ref)`` do not match ``ref``,
+            or when both ref and alt are empty.
     """
     import logging
     log = logging.getLogger(__name__)
 
-    if len(ref) != len(alt):
+    ref = normalize_allele(ref)
+    alt = normalize_allele(alt)
+    if ref == "" and alt == "":
         raise ValueError(
-            f"get_centered_window only supports SNVs/MNVs of equal length: "
-            f"got ref={ref!r} (len {len(ref)}) vs alt={alt!r} (len {len(alt)})."
+            "Both ref and alt alleles are empty after normalization — "
+            "nothing to score."
         )
 
-    # Convert 1-based variant position to 0-based half-open window
-    # centred on the variant. For length L and 0-based variant index v,
-    # the centred window is [v - L//2, v - L//2 + L).
+    # Convert 1-based variant position to 0-based half-open. The variant
+    # starts at offset `half` inside each returned window.
     pos_0based = pos_1based - 1
     half = length // 2
-    win_start = pos_0based - half
-    win_end = win_start + length
 
-    ref_seq = extract_sequence_with_padding(
-        fasta_path, chrom, win_start, win_end, length,
+    # When alt is shorter than ref (deletion), the alt_seq window pulls
+    # extra genomic flank on the right; fetch enough to cover that.
+    extra_right = max(0, len(ref) - len(alt))
+    fetch_len = length + extra_right
+    fetch_start = pos_0based - half
+    fetch_end = fetch_start + fetch_len
+
+    big_window = extract_sequence_with_padding(
+        fasta_path, chrom, fetch_start, fetch_end, fetch_len,
     )
 
-    # The variant occupies positions [half, half + len(ref)) inside the window
-    var_offset = half
-    seq_ref_base = ref_seq[var_offset:var_offset + len(ref)].upper()
-    if seq_ref_base != ref.upper():
-        msg = (
-            f"Reference allele mismatch at {chrom}:{pos_1based}: "
-            f"expected {ref!r}, found {seq_ref_base!r} in FASTA. "
-            f"Check coordinate convention (chorus uses 1-based inclusive) "
-            f"or strand."
-        )
-        if strict:
-            raise ValueError(msg)
-        log.warning(msg)
+    # Sanity-check the ref allele against the FASTA when present.
+    if len(ref) > 0:
+        seq_ref_base = big_window[half:half + len(ref)].upper()
+        if seq_ref_base != ref:
+            msg = (
+                f"Reference allele mismatch at {chrom}:{pos_1based}: "
+                f"expected {ref!r}, found {seq_ref_base!r} in FASTA. "
+                f"Check coordinate convention (chorus uses 1-based inclusive) "
+                f"or strand."
+            )
+            if strict:
+                raise ValueError(msg)
+            log.warning(msg)
 
-    alt_seq = ref_seq[:var_offset] + alt.upper() + ref_seq[var_offset + len(ref):]
+    # ref_seq: trim the (possibly oversized) big_window down to `length`
+    # bp, with the ref allele anchored at `half`.
+    ref_seq = big_window[:length]
+
+    # alt_seq: splice. Left flank is the first `half` bp of the genomic
+    # context; then alt; then right flank starting after the ref's
+    # footprint, padded out to `length`.
+    left_flank = big_window[:half]
+    right_flank_genome_start = half + len(ref)
+    right_flank_needed = length - half - len(alt)
+    right_flank = big_window[
+        right_flank_genome_start:right_flank_genome_start + right_flank_needed
+    ]
+    alt_seq = left_flank + alt + right_flank
+
+    if len(alt_seq) != length:
+        raise ValueError(
+            f"Internal error building alt_seq: got len={len(alt_seq)}, "
+            f"expected {length}. ref={ref!r} alt={alt!r} pos={pos_1based}"
+        )
+
     return ref_seq, alt_seq

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ with open("requirements.txt", "r", encoding="utf-8") as fh:
 
 setup(
     name="chorus",
-    version="0.5.4",
+    version="0.5.5",
     author="Pinello Lab",
     author_email="lucapinello@gmail.com",
     description="A unified interface for genomic sequence oracles",

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1213,6 +1213,70 @@ class TestCausalPrioritization:
         assert result.scores[0].variant_id == "rs1"
         assert result.scores[0].composite > result.scores[1].composite
 
+    def test_prioritize_causal_variants_indels(self):
+        """Indels score through prioritize_causal_variants without error."""
+        from chorus.analysis.causal import prioritize_causal_variants, CausalResult
+        from chorus.utils.ld import LDVariant
+
+        oracle = MagicMock()
+        oracle.name = "test_oracle"
+        def mock_predict(**kwargs):
+            return _make_variant_result(
+                {"DNASE:K562": np.ones(1000, dtype=np.float32)},
+                {"DNASE:K562": np.ones(1000, dtype=np.float32) * 1.5},
+                position=kwargs["variant_position"],
+                alleles=kwargs["alleles"],
+            )
+        oracle.predict_variant_effect = mock_predict
+
+        ld_variants = [
+            LDVariant("rs_snv", "chr1", 1000500, "A", "G", r2=1.0, is_sentinel=True, kind="snv"),
+            LDVariant("rs_del", "chr1", 1001500, "A", "",  r2=0.9, kind="deletion"),
+            LDVariant("rs_ins", "chr1", 1002500, "",  "CT", r2=0.85, kind="insertion"),
+        ]
+        result = prioritize_causal_variants(
+            oracle,
+            {"chrom": "chr1", "pos": 1000500, "ref": "A", "alt": "G", "id": "rs_snv"},
+            ld_variants,
+            assay_ids=["DNASE:K562"],
+        )
+        assert isinstance(result, CausalResult)
+        # All three scored — none skipped
+        assert len(result.scores) == 3
+        # kind preserved on the per-variant score record
+        kinds = {s.variant_id: s.kind for s in result.scores}
+        assert kinds == {"rs_snv": "snv", "rs_del": "deletion", "rs_ins": "insertion"}
+
+    def test_prioritize_causal_variants_snvs_only(self):
+        """snvs_only=True drops insertions/deletions before scoring."""
+        from chorus.analysis.causal import prioritize_causal_variants
+        from chorus.utils.ld import LDVariant
+
+        oracle = MagicMock()
+        oracle.name = "test_oracle"
+        oracle.predict_variant_effect = lambda **kw: _make_variant_result(
+            {"DNASE:K562": np.ones(1000, dtype=np.float32)},
+            {"DNASE:K562": np.ones(1000, dtype=np.float32) * 1.2},
+            position=kw["variant_position"],
+            alleles=kw["alleles"],
+        )
+
+        ld_variants = [
+            LDVariant("rs_snv", "chr1", 1000500, "A", "G", r2=1.0, is_sentinel=True, kind="snv"),
+            LDVariant("rs_del", "chr1", 1001500, "A", "",  r2=0.9, kind="deletion"),
+            LDVariant("rs_ins", "chr1", 1002500, "",  "CT", r2=0.85, kind="insertion"),
+        ]
+        result = prioritize_causal_variants(
+            oracle,
+            {"chrom": "chr1", "pos": 1000500, "ref": "A", "alt": "G", "id": "rs_snv"},
+            ld_variants,
+            assay_ids=["DNASE:K562"],
+            snvs_only=True,
+        )
+        # Only the SNV survives
+        assert len(result.scores) == 1
+        assert result.scores[0].variant_id == "rs_snv"
+
     def test_composite_score_components(self):
         from chorus.analysis.causal import CausalVariantScore, _compute_composites, CausalWeights
 
@@ -1348,8 +1412,96 @@ class TestLDUtils:
         assert len(result) == 2  # rs999 filtered out (r2=0.30 < 0.8)
         assert result[0].variant_id == "rs12740374"
         assert result[0].is_sentinel
+        assert result[0].kind == "snv"
         assert result[1].variant_id == "rs629301"
         assert result[1].r2 == 0.95
+
+    def test_parse_ld_response_dash_indel(self):
+        """LDlink ``"-"`` notation is normalised to ``""`` and kind set."""
+        from chorus.utils.ld import parse_ld_response
+
+        tsv = (
+            "RS_Number\tCoord\tAlleles\tMAF\tDistance\tDprime\tR2\n"
+            "rs_sentinel\tchr6:4570564\t(G/T)\t0.05\t0\t1.0\t1.0\n"
+            "rs_del\tchr6:4573808\t(A/-)\t0.05\t3244\t0.95\t0.85\n"
+            "rs_ins\tchr6:4594841\t(-/CT)\t0.05\t24277\t0.95\t0.82\n"
+            "rs_bigdel\tchr6:4570564\t(GAAAAAATAAAAA/-)\t0.05\t0\t0.95\t0.90\n"
+        )
+        result = parse_ld_response(tsv, r2_threshold=0.5)
+        kinds = {v.variant_id: v.kind for v in result}
+        alts = {v.variant_id: v.alt for v in result}
+        refs = {v.variant_id: v.ref for v in result}
+
+        assert kinds["rs_del"] == "deletion"
+        assert alts["rs_del"] == ""
+        assert refs["rs_del"] == "A"
+
+        assert kinds["rs_ins"] == "insertion"
+        assert alts["rs_ins"] == "CT"
+        assert refs["rs_ins"] == ""
+
+        assert kinds["rs_bigdel"] == "deletion"
+        assert refs["rs_bigdel"] == "GAAAAAATAAAAA"
+
+    def test_parse_ld_response_multi_allelic_alt(self):
+        """(A/G,T) comma-split → two LDVariant records at the same position."""
+        from chorus.utils.ld import parse_ld_response
+
+        tsv = (
+            "RS_Number\tCoord\tAlleles\tMAF\tDistance\tDprime\tR2\n"
+            "rs_multi\tchr1:100\t(A/G,T)\t0.05\t0\t1.0\t1.0\n"
+        )
+        result = parse_ld_response(tsv, r2_threshold=0.5)
+        assert len(result) == 2
+        assert all(v.position == 100 and v.ref == "A" for v in result)
+        assert {v.alt for v in result} == {"G", "T"}
+
+    def test_parse_ld_response_correlated_alleles_fanout(self):
+        """Correlated_Alleles ``T=CT,A=-`` → two LDVariant records.
+
+        Per the v0.5.5 contract: each ``SENT=PROXY`` pair becomes its
+        own variant — ``(ref=SENT, alt=PROXY)`` — so a row with
+        Correlated_Alleles emits two scored variants at the same locus.
+        """
+        from chorus.utils.ld import parse_ld_response
+
+        tsv = (
+            "RS_Number\tCoord\tAlleles\tMAF\tDistance\tDprime\tR2\tCorrelated_Alleles\n"
+            "rs_sentinel\tchr6:4580233\t(A/G)\t0.06\t0\t1.0\t1.0\tT=A,A=G\n"
+            ".\tchr6:4581552\t(CT/-)\t0.07\t1319\t0.95\t0.78\tT=CT,A=-\n"
+        )
+        result = parse_ld_response(tsv, r2_threshold=0.5)
+
+        # sentinel SNV row → 2 records; deletion row → 2 records
+        assert len(result) == 4
+        sentinel_records = [v for v in result if v.is_sentinel]
+        assert len(sentinel_records) == 2
+        assert {(v.ref, v.alt) for v in sentinel_records} == {("T", "A"), ("A", "G")}
+
+        proxy_records = [v for v in result if not v.is_sentinel]
+        assert {(v.ref, v.alt, v.kind) for v in proxy_records} == {
+            ("T", "CT", "complex"),  # insertion of C before T
+            ("A", "", "deletion"),
+        }
+
+    def test_fetch_ld_variants_snvs_only_filter(self):
+        """The ``snvs_only`` filter on fetch_ld_variants drops non-SNV kinds."""
+        from chorus.utils.ld import parse_ld_response
+
+        tsv = (
+            "RS_Number\tCoord\tAlleles\tMAF\tDistance\tDprime\tR2\n"
+            "rs_snv\tchr1:100\t(A/G)\t0.05\t0\t1.0\t1.0\n"
+            "rs_del\tchr1:200\t(A/-)\t0.05\t100\t0.95\t0.9\n"
+            "rs_ins\tchr1:300\t(-/CT)\t0.05\t200\t0.95\t0.9\n"
+        )
+        # parse_ld_response itself doesn't filter; the filter is in
+        # fetch_ld_variants (which we can't call offline because it
+        # needs an LDlink token). Verify the building block: every
+        # parsed variant has a `kind` we can filter on.
+        result = parse_ld_response(tsv, r2_threshold=0.5)
+        snv_only = [v for v in result if v.kind == "snv"]
+        assert len(snv_only) == 1
+        assert snv_only[0].variant_id == "rs_snv"
 
 
 # ── Enriched dataclass field tests ────────────────────────────────────

--- a/tests/test_prediction_methods.py
+++ b/tests/test_prediction_methods.py
@@ -285,50 +285,73 @@ class TestPredictionMethods:
                 assay_ids=["DNase:K562"],
             )
 
-    def test_indel_rejected_before_model_run(self):
-        """predict_variant_effect substitutes a single base at the
-        variant site; passing an indel (``alt='GT'`` or ``ref='GT'``)
-        would be treated as a 1-base swap and score nonsense. Validate
-        up-front — don't burn model time on invalid input.
+    def test_indel_accepted_and_scored(self):
+        """predict_variant_effect now accepts indels and multi-base
+        substitutions (v0.5.5). This test exercises the public API for
+        each variant kind end-to-end via the mocked oracle setup and
+        verifies the call returns a non-empty result dict.
 
-        Regression for v20 §14.2 finding (LegNet silently accepted
-        ``alleles=['G','GT']``).
+        v0.5.5 changed the contract: prior to this release the call
+        raised ``InvalidRegionError("…single-nucleotide variant…")``;
+        now indels go through. Callers that want the old behaviour
+        should set ``snvs_only=True`` on the relevant downstream tool.
         """
+        # Mock genome is all 'A' on chr1 so we choose ref alleles that
+        # match the genome to avoid the ref-mismatch warning path.
+        # 4-bp deletion (LDlink ``"-"`` notation accepted internally
+        # via normalize_allele).
+        r = self.oracle.predict_variant_effect(
+            genomic_region="chr1:100000-200000",
+            variant_position="chr1:150000",
+            alleles=["AAAA", "-"],
+            assay_ids=["DNase:K562"],
+        )
+        assert r["effect_sizes"]
+
+        # 2-bp insertion (LDlink-style ``"-"`` ref).
+        r = self.oracle.predict_variant_effect(
+            genomic_region="chr1:100000-200000",
+            variant_position="chr1:150000",
+            alleles=["-", "GT"],
+            assay_ids=["DNase:K562"],
+        )
+        assert r["effect_sizes"]
+
+        # MNV (same-length multi-base substitution).
+        r = self.oracle.predict_variant_effect(
+            genomic_region="chr1:100000-200000",
+            variant_position="chr1:150000",
+            alleles=["AA", "GT"],
+            assay_ids=["DNase:K562"],
+        )
+        assert r["effect_sizes"]
+
+        # VCF-style anchored insertion (ref="A", alt="AGT" — keeps the
+        # genome anchor at the variant position; insert "GT" after it).
+        r = self.oracle.predict_variant_effect(
+            genomic_region="chr1:100000-200000",
+            variant_position="chr1:150000",
+            alleles=["A", "AGT"],
+            assay_ids=["DNase:K562"],
+        )
+        assert r["effect_sizes"]
+
+    def test_predict_variant_effect_rejects_garbage_allele(self):
+        """Non-ACGTN bases are still rejected (post-v0.5.5 validation)."""
         from chorus.core.exceptions import InvalidRegionError
 
-        # insertion: alt longer than 1
-        with pytest.raises(InvalidRegionError, match="single-nucleotide variant"):
-            self.oracle.predict_variant_effect(
-                genomic_region="chr1:100000-200000",
-                variant_position="chr1:150000",
-                alleles=["G", "GT"],
-                assay_ids=["DNase:K562"],
-            )
-
-        # deletion: ref longer than 1
-        with pytest.raises(InvalidRegionError, match="single-nucleotide variant"):
-            self.oracle.predict_variant_effect(
-                genomic_region="chr1:100000-200000",
-                variant_position="chr1:150000",
-                alleles=["GT", "G"],
-                assay_ids=["DNase:K562"],
-            )
-
-        # empty string allele
-        with pytest.raises(InvalidRegionError, match="single-nucleotide variant"):
-            self.oracle.predict_variant_effect(
-                genomic_region="chr1:100000-200000",
-                variant_position="chr1:150000",
-                alleles=["G", ""],
-                assay_ids=["DNase:K562"],
-            )
-
-        # Invalid base character
-        with pytest.raises(InvalidRegionError, match="single-nucleotide variant"):
+        with pytest.raises(InvalidRegionError):
             self.oracle.predict_variant_effect(
                 genomic_region="chr1:100000-200000",
                 variant_position="chr1:150000",
                 alleles=["G", "X"],
+                assay_ids=["DNase:K562"],
+            )
+        with pytest.raises(InvalidRegionError):
+            self.oracle.predict_variant_effect(
+                genomic_region="chr1:100000-200000",
+                variant_position="chr1:150000",
+                alleles=["G", "AT?"],
                 assay_ids=["DNase:K562"],
             )
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,7 +14,9 @@ from chorus.utils import (
     get_gc_content,
     quantile_normalize,
     minmax_normalize,
-    zscore_normalize
+    zscore_normalize,
+    normalize_allele,
+    classify_variant,
 )
 from chorus.core.exceptions import InvalidRegionError, FileFormatError
 
@@ -68,7 +70,82 @@ class TestSequenceUtils:
         # Mismatch
         with pytest.raises(ValueError):
             apply_variant(ref_seq, 5, "A", "T")  # Position 5 is T, not A
-    
+
+    def test_normalize_allele_table(self):
+        """LDlink ``"-"`` and ``None`` collapse to ``""``; bases uppercase + validated."""
+        assert normalize_allele("-") == ""
+        assert normalize_allele("") == ""
+        assert normalize_allele(None) == ""
+        assert normalize_allele("A") == "A"
+        assert normalize_allele("a") == "A"
+        assert normalize_allele("  CT  ") == "CT"
+        assert normalize_allele("GAAAAAATAAAAA") == "GAAAAAATAAAAA"
+
+        for bad in ("X", "AT?", "-A"):
+            with pytest.raises(InvalidRegionError):
+                normalize_allele(bad)
+
+    def test_classify_variant(self):
+        assert classify_variant("A", "G") == "snv"
+        assert classify_variant("A", "") == "deletion"
+        assert classify_variant("", "CT") == "insertion"
+        assert classify_variant("AT", "GC") == "mnv"
+        assert classify_variant("A", "AT") == "complex"  # VCF-style anchored
+        assert classify_variant("TA", "TAC") == "complex"
+
+    def test_get_centered_window_indels(self):
+        """Indels: alt_seq is `length` bp with the variant at the centre.
+
+        Uses a synthetic single-chrom FASTA so the test stays self-
+        contained and doesn't depend on hg38 being present.
+        """
+        from chorus.utils import get_centered_window
+        import pysam
+
+        # All-A test genome on chr1, 10 kb long.
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".fa", delete=False) as f:
+            f.write(">chr1\n" + "A" * 10000 + "\n")
+            fa = f.name
+        try:
+            pysam.faidx(fa)
+            length = 100
+
+            # SNV (backward compat): ref/alt both 1 bp, equal lengths
+            r, a = get_centered_window(fa, "chr1", 5000, length, "A", "C")
+            assert len(r) == length == len(a)
+            assert a[length // 2] == "C"
+
+            # Pure deletion: ref="A" alt=""
+            r, a = get_centered_window(fa, "chr1", 5000, length, "A", "")
+            assert len(r) == length == len(a)
+            # alt has one fewer A at the centre, but is padded back to length
+            assert r.count("A") == length
+            assert a.count("A") == length  # still all A's since genome is uniform
+
+            # Pure insertion: ref="" alt="GT"
+            r, a = get_centered_window(fa, "chr1", 5000, length, "", "GT")
+            assert len(r) == length == len(a)
+            # The inserted "GT" lives at the centre of alt_seq
+            assert a[length // 2 : length // 2 + 2] == "GT"
+
+            # 4-bp deletion (LDlink dash notation)
+            r, a = get_centered_window(fa, "chr1", 5000, length, "AAAA", "-")
+            assert len(r) == length == len(a)
+            assert r[length // 2 : length // 2 + 4] == "AAAA"
+
+            # VCF-style anchored insertion: ref="A" alt="AGT"
+            r, a = get_centered_window(fa, "chr1", 5000, length, "A", "AGT")
+            assert len(r) == length == len(a)
+            assert a[length // 2 : length // 2 + 3] == "AGT"
+
+            # MNV equal length
+            r, a = get_centered_window(fa, "chr1", 5000, length, "AA", "GT")
+            assert len(r) == length == len(a)
+            assert a[length // 2 : length // 2 + 2] == "GT"
+        finally:
+            os.unlink(fa)
+            os.unlink(fa + ".fai")
+
     def test_parse_vcf(self):
         """Test VCF parsing."""
         # Create temporary VCF file


### PR DESCRIPTION
## Summary

The collaborator's chr6 GWAS workflow surfaced variants that v0.5.4 silently mis-handled: 13-bp deletions, 1-bp insertions/deletions, VCF-style anchored indels, and multi-allelic LDlink rows where the second SENT=PROXY mapping in `Correlated_Alleles` was dropped. Root cause: the SNV-only validator at `chorus/core/base.py:415-424`. Downstream machinery (`apply_variant`, `Interval.replace`, `parse_ld_response`) already supported any-length swaps but never saw them.

## What's in v0.5.5

| Surface | Change |
|---|---|
| `chorus/utils/sequence.py` (new helpers) | `normalize_allele(a)` accepts LDlink `"-"` and `None`, uppercases, validates ACGTN. `classify_variant(ref, alt)` → `snv` / `insertion` / `deletion` / `mnv` / `complex` |
| `chorus/core/base.py` `predict_variant_effect` | SNV-only gate replaced. Accepts indels, MNVs, VCF-style anchored variants. Auto-widens `region_interval` to fit `len(ref)` |
| `chorus/utils/sequence.py` `get_centered_window` | Equal-length restriction lifted. Returns `length`-bp `ref_seq` + `alt_seq` for SNV / insertion / deletion / MNV / anchored indel |
| `chorus/utils/ld.py` `parse_ld_response` | Now parses `Correlated_Alleles` (`T=CT,A=-`) into **two** LDVariant records per row (per user direction). Comma-splits multi-allelic alts. `LDVariant.kind` classifies each |
| `fetch_ld_variants`, `prioritize_causal_variants`, `fine_map_causal_variant` | New `snvs_only: bool = False` filter. Default scores everything; pass `True` to reproduce pre-v0.5.5 behaviour |
| `CausalVariantScore.kind` | Surfaced in `to_dict()` and markdown report (`"rs_del (deletion)"` style suffix) |
| Tests | Flipped `test_indel_rejected_before_model_run` → `test_indel_accepted_and_scored`. **+9 new tests**: `normalize_allele`, `classify_variant`, `get_centered_window` indels, `parse_ld_response` fanout (dash + multi-alt + Correlated_Alleles), `snvs_only` filter, prioritize indel/snvs_only |

## How a `T=CT,A=-` row now parses (per user clarification)

Per the user's explicit answer in plan-mode: "two variants per row, both scored". Each `SENT=PROXY` pair in `Correlated_Alleles` becomes its own LDVariant where `ref = SENT, alt = PROXY`. So a row with `(CT/-) ... T=CT,A=-` emits:

1. `(ref=T, alt=CT, kind=complex)` — insertion of C before T
2. `(ref=A, alt="", kind=deletion)`

Both flow through `prioritize_causal_variants` and end up in the ranking table.

## Backward-compat note

This release **relaxes** a long-standing validation contract. Callers that depended on `InvalidRegionError("…single-nucleotide variant…")` to filter out indels will now have those variants flow through and be scored. Migration: pass `snvs_only=True` to `fine_map_causal_variant` / `prioritize_causal_variants` / `fetch_ld_variants`.

## Verification

- ✅ Targeted smoke checks (helper tables, LDlink fanout): all pass
- ✅ Chorus base test suite: **389 passed, 2 skipped, 0 failed** (13:19) — up from 379 in v0.5.4 (+10 new tests)

Full audit: [audits/2026-05-13_v0.5.5_indel_variant_prioritization/](https://github.com/pinellolab/chorus/tree/fix/v0.5.5-indel-variant-prioritization/audits/2026-05-13_v0.5.5_indel_variant_prioritization)

## Test plan
- [ ] Reviewer eyeballs the audit report
- [ ] Reviewer confirms the Correlated_Alleles fanout semantics match their intent
- [ ] On approval: merge → tag v0.5.5 → GitHub release

🤖 Generated with [Claude Code](https://claude.com/claude-code)