### PR TITLE
Fix variant-scoring window collapse for fixed-input oracles (ChromBPNet/Borzoi)

### DIFF
--- a/audits/2026-06-17_windowing_normalization_P0.md
+++ b/audits/2026-06-17_windowing_normalization_P0.md
@@ -1,8 +1,24 @@
 # P0 follow-up — variant-scoring window collapse for fixed-input oracles (+ normalization entanglement)
 
 **Date:** 2026-06-17
-**Status:** documented; **NOT fixed in the reproducibility PR** (needs a background-CDF rebuild — see §4)
+**Status:** **query-side fix IMPLEMENTED** (central region-widening in `predict_variant_effect`;
+ChromBPNet 1 bp region now reproduces +1.374, full suite 407 passed/0 failed). **Background-CDF
+rebuild is the required companion** and is in progress on GPU (ml008) — until the rebuilt CDFs
+are uploaded, the percentile/normalized scores for *affected* oracles are inconsistent with the
+new (correct) query window, so this fix must not be merged before the CDF rebuild lands.
 **Severity:** P0 for any *conversational / MCP* variant-effect magnitude on a fixed-input oracle
+
+## Root cause (confirmed)
+
+Not N-padding of the input (the input is real genome). For a region smaller than the oracle's
+input window, the returned ``prediction_interval`` spans a different number of bp than the
+values array implies (``prediction_interval_bp / len(values) != bin_size``), so the scorer maps
+the 501 bp window to the wrong array indices and the effect collapses ~4×. ChromBPNet (1 bp
+region): values=2114 but ``prediction_interval``=1000 bp → mismatch → +0.318; full 2114 bp
+region: values=2115, ``prediction_interval``=2115 bp → match → +1.374. Fix = widen the region
+to the oracle's input window centered on the variant in ``predict_variant_effect`` so the
+interval and values always agree. Enformer/AlphaGenome were already consistent (Enformer slices
+its prediction to the output window; AlphaGenome strips N-padding), so the fix is a no-op for them.
 
 ## Summary
 

--- a/audits/2026-06-17_windowing_normalization_P0.md
+++ b/audits/2026-06-17_windowing_normalization_P0.md
@@ -1,12 +1,26 @@
 # P0 follow-up — variant-scoring window collapse for fixed-input oracles (+ normalization entanglement)
 
 **Date:** 2026-06-17
-**Status:** **query-side fix IMPLEMENTED** (central region-widening in `predict_variant_effect`;
-ChromBPNet 1 bp region now reproduces +1.374, full suite 407 passed/0 failed). **Background-CDF
-rebuild is the required companion** and is in progress on GPU (ml008) — until the rebuilt CDFs
-are uploaded, the percentile/normalized scores for *affected* oracles are inconsistent with the
-new (correct) query window, so this fix must not be merged before the CDF rebuild lands.
+**Status:** **FIXED (independently mergeable) — NO CDF rebuild needed.** Central region-widening
+in `predict_variant_effect`; ChromBPNet 1 bp region now reproduces +1.374, full suite 407
+passed/0 failed.
 **Severity:** P0 for any *conversational / MCP* variant-effect magnitude on a fixed-input oracle
+
+## No background-CDF rebuild is required (corrected)
+
+An earlier draft of this note claimed the fix needed a companion CDF rebuild. That was wrong.
+The per-oracle background builders (`scripts/build_backgrounds_chrombpnet.py`,
+`scripts/build_backgrounds_borzoi.py`) do **not** score through `predict_variant_effect`; they
+one-hot-encode and call the Keras/PyTorch model **directly** on the **full input window**
+(`INPUT_LENGTH = 2114` for ChromBPNet, `524_288` for Borzoi, centered on each SNP). So the
+published CDFs were always built on the **full window**.
+
+Therefore the windowing bug made *pre-fix queries* (collapsed to a sub-input region) inconsistent
+with the full-window CDFs — the percentiles were already wrong pre-fix. The windowing fix makes
+queries use the full window, which **matches** the existing CDFs, so it corrects **both** the raw
+effect and the percentile with no rebuild. Evidence (ChromBPNet rs12740374/HepG2 DNASE): pre-fix
+collapsed +0.318 → quantile 0.9616 (wrong); post-fix full +1.374 → quantile 0.9995, consistent
+with the committed full-window walkthrough (+1.241 → 0.9987). The fix can be merged on its own.
 
 ## Root cause (confirmed)
 

--- a/chorus/core/base.py
+++ b/chorus/core/base.py
@@ -392,6 +392,22 @@ class OracleBase(ABC):
         region_start_0based = region_start - 1  # 1-based inclusive → 0-based
         var_pos_0based = var_pos - 1            # 1-based → 0-based
 
+        # Widen a sub-input region to the oracle's full input window, centered
+        # on the variant (pulling real genome). Fixed-input oracles (ChromBPNet,
+        # etc.) otherwise return a ``prediction_interval`` whose length differs
+        # from the values array, which breaks the scorer's genomic→array index
+        # mapping and collapses the variant effect ~4× (audit 2026-06-17). The
+        # model always sees a full, real-genome, variant-centered window this
+        # way; AlphaGenome (which strips N-padding internally) is unaffected.
+        # Oracles that expose no integer ``sequence_length`` keep the caller's
+        # region unchanged.
+        _seqlen = getattr(self, "sequence_length", None)
+        if isinstance(_seqlen, int) and _seqlen >= 2 and \
+                (region_end - region_start_0based) < _seqlen:
+            half = _seqlen // 2
+            region_start_0based = max(0, var_pos_0based - half)
+            region_end = region_start_0based + _seqlen
+
         # Parse alleles
         if isinstance(alleles, pd.DataFrame):
             ref_allele = alleles.iloc[0]['ref']


### PR DESCRIPTION
## Summary
Fixed-input oracles (ChromBPNet, Borzoi) collapsed variant effects ~4x when scored on a region smaller than their input window — the conversational path (`analyze_variant_multilayer`/`_auto_region` → 1 bp region) under-reported ChromBPNet (+0.318 vs the correct +1.374) and similar for Borzoi. Root cause: for a sub-input region, the returned `prediction_interval` bp-span disagreed with the values-array length (`prediction_interval_bp / len(values) != bin_size`), so the scorer mapped the 501 bp window to the wrong array indices.

## Fix
`predict_variant_effect` (chorus/core/base.py) now widens a sub-input region to the oracle's full input window (`sequence_length`), centered on the variant, pulling real genome — so the prediction interval and values always agree. Enformer (slices its prediction to the output window) and AlphaGenome (strips N-padding) were already consistent → no-op for them. Oracles without an integer `sequence_length` are untouched.

## No CDF rebuild needed
The per-track background CDFs were built by scripts that call the model **directly on the full input window** (not through `predict_variant_effect`), so they are full-window. The fix makes queries full-window too → consistent. Verified: post-fix ChromBPNet +1.374 → quantile 0.9995 (matches the committed full-window walkthrough's 0.9987); the pre-fix collapsed +0.318 → 0.9616 was the inconsistent one. Details: `audits/2026-06-17_windowing_normalization_P0.md`.

## Validation
- ChromBPNet rs12740374/HepG2: 1 bp / 1000 bp / 2114 bp regions now all give +1.374 (was +0.318 for the small ones).
- Enformer/LegNet: consistent `prediction_interval`↔values, sensible values (fix is a no-op).
- Full test suite: **407 passed, 5 skipped, 0 failed** (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)