### PR TITLE
fix(mcp,regen): MCP help says 7 oracles (incl. EPInformer-seq); LegNet scored single-window

### DIFF
--- a/chorus/mcp/server.py
+++ b/chorus/mcp/server.py
@@ -276,7 +276,7 @@ def recommend_alphagenome_backend(window_size_bp: int) -> dict:
 @mcp.tool()
 @_safe_tool
 def list_oracles() -> dict:
-    """List all genomic oracles (6 plus an alternative PyTorch backend for AlphaGenome) with their specs, environment install status, and loaded status.
+    """List all genomic oracles (7 plus an alternative PyTorch backend for AlphaGenome) with their specs, environment install status, and loaded status.
 
     No model loading is required — this returns static metadata plus live status.
     """
@@ -1730,7 +1730,7 @@ def getting_started() -> str:
     return (
         "You are using Chorus, a unified interface for genomic deep-learning oracles.\n\n"
         "## Getting Started\n\n"
-        "1. **Discover oracles**: Call `list_oracles()` to see all 6 available oracles "
+        "1. **Discover oracles**: Call `list_oracles()` to see all 7 available oracles "
         "and which ones have their environments installed.\n\n"
         "2. **Choose an oracle**:\n"
         "   - **AlphaGenome** (recommended): 1Mb window, 5,731 tracks, 1bp resolution. Best for variant analysis.\n"
@@ -1738,7 +1738,8 @@ def getting_started() -> str:
         "   - **Borzoi**: 196kb output at 32bp resolution, 7,611 tracks. Good for distal gene expression.\n"
         "   - **ChromBPNet**: 1bp resolution, 1kb window. Best for motif-level TF binding analysis.\n"
         "   - **Sei**: Regulatory element classification (not per-track signal).\n"
-        "   - **LegNet**: MPRA activity prediction for short sequences.\n\n"
+        "   - **LegNet**: MPRA activity prediction for short sequences.\n"
+        "   - **EPInformer-seq**: scalar enhancer activity from 2,114bp sequence (per-cell DNase + H3K27ac).\n\n"
         "3. **Find tracks**: Call `list_tracks(oracle_name, query='...')` to search for "
         "relevant assays (e.g. 'DNASE K562', 'CAGE liver', 'GATA1').\n\n"
         "4. **Load an oracle**: Call `load_oracle(oracle_name)`. This takes 30s-5min. "

--- a/examples/walkthroughs/validation/SORT1_rs12740374_multioracle/example_output.json
+++ b/examples/walkthroughs/validation/SORT1_rs12740374_multioracle/example_output.json
@@ -46,7 +46,7 @@
       "oracles": {
         "chrombpnet": null,
         "legnet": {
-          "raw_score": 0.29897384718060493,
+          "raw_score": 0.3470577001571655,
           "assay_id": "LentiMPRA:HepG2",
           "cell_type": "HepG2",
           "quantile_score": null,
@@ -110,6 +110,6 @@
     "tracks_requested": "assay_ids as listed in each per-oracle request",
     "cell_types": [],
     "notes": [],
-    "generated_at": "2026-06-17 15:29 UTC"
+    "generated_at": "2026-06-17 19:29 UTC"
   }
 }

--- a/examples/walkthroughs/validation/SORT1_rs12740374_multioracle/example_output.md
+++ b/examples/walkthroughs/validation/SORT1_rs12740374_multioracle/example_output.md
@@ -3,14 +3,14 @@
 - **Variant:** chr1:109,274,968 G>T
 - **Gene:** SORT1
 - **Oracles:** chrombpnet, legnet, alphagenome
-- **Generated:** 2026-06-17 15:29 UTC
+- **Generated:** 2026-06-17 19:29 UTC
 
 ## Cross-oracle consensus
 
 | Layer | chrombpnet | legnet | alphagenome | Agreement |
 |---|---|---|---|---|
 | Chromatin accessibility (DNASE/ATAC) (log2FC) | +1.374 · DNASE:HepG2 | — | +1.333 · DNASE:HepG2 | all ↑ |
-| Promoter activity (MPRA) (Δ (alt−ref)) | — | +0.299 · LentiMPRA:HepG2 | — | only ↑ (n=1) |
+| Promoter activity (MPRA) (Δ (alt−ref)) | — | +0.347 · LentiMPRA:HepG2 | — | only ↑ (n=1) |
 | Transcription factor binding (ChIP-TF) (log2FC) | — | — | +2.767 · CHIP:CEBPA:HepG2 | only ↑ (n=1) |
 | Histone modifications (ChIP-Histone) (log2FC) | — | — | +1.264 · CHIP:H3K27ac:HepG2 | only ↑ (n=1) |
 | TSS activity (CAGE/PRO-CAP) (log2FC) | — | — | +1.525 · CAGE:HepG2 | only ↑ (n=1) |

--- a/examples/walkthroughs/validation/SORT1_rs12740374_multioracle/legnet_variant_report.json
+++ b/examples/walkthroughs/validation/SORT1_rs12740374_multioracle/legnet_variant_report.json
@@ -23,9 +23,9 @@
             "assay_type": "LentiMPRA",
             "cell_type": "HepG2",
             "layer": "promoter_activity",
-            "ref_value": -0.04832424595952034,
-            "alt_value": 0.2506496012210846,
-            "raw_score": 0.29897384718060493,
+            "ref_value": 0.37100595235824585,
+            "alt_value": 0.7180636525154114,
+            "raw_score": 0.3470577001571655,
             "description": "LentiMPRA:HepG2"
           }
         ]
@@ -36,9 +36,9 @@
           "assay_type": "LentiMPRA",
           "cell_type": "HepG2",
           "layer": "promoter_activity",
-          "ref_value": -0.04832424595952034,
-          "alt_value": 0.2506496012210846,
-          "raw_score": 0.29897384718060493,
+          "ref_value": 0.37100595235824585,
+          "alt_value": 0.7180636525154114,
+          "raw_score": 0.3470577001571655,
           "description": "LentiMPRA:HepG2"
         }
       ]
@@ -52,6 +52,6 @@
     "tracks_requested": "1 tracks",
     "cell_types": [],
     "notes": [],
-    "generated_at": "2026-06-17 15:25 UTC"
+    "generated_at": "2026-06-17 19:29 UTC"
   }
 }

--- a/examples/walkthroughs/validation/SORT1_rs12740374_multioracle/rs12740374_SORT1_legnet_report.html
+++ b/examples/walkthroughs/validation/SORT1_rs12740374_multioracle/rs12740374_SORT1_legnet_report.html
@@ -57,14 +57,14 @@ tr:hover td { background: #e9ecef; }
 <li><strong>Oracle:</strong> legnet</li>
 <li><strong>Normalizer:</strong> chorus per-track v1</li>
 <li><strong>Tracks requested:</strong> 1 tracks</li>
-<li><strong>Generated:</strong> 2026-06-17 15:25 UTC</li>
+<li><strong>Generated:</strong> 2026-06-17 19:29 UTC</li>
 </ul>
 </section>
 <p class="meta"><b>Variant:</b> chr1:109274968 G&gt;T</p>
 <p class="meta"><b>Oracle:</b> legnet</p>
 <p class="meta"><b>Gene:</b> SORT1</p>
 <p class="meta"><b>Other nearby genes:</b> CELSR2</p>
-<p class="meta" style="margin-top:0.5rem;padding:0.6rem 0.8rem;background:#f0f7ff;border-left:3px solid #3b82f6;border-radius:4px"><b>Summary:</b> Promoter activity (MPRA): moderate activation (+0.30, LentiMPRA:HepG2).</p>
+<p class="meta" style="margin-top:0.5rem;padding:0.6rem 0.8rem;background:#f0f7ff;border-left:3px solid #3b82f6;border-radius:4px"><b>Summary:</b> Promoter activity (MPRA): strong activation (+0.35, LentiMPRA:HepG2).</p>
 <section class="how-to-read"><p style='margin:0'><b>How to read this report.</b> Every numeric effect below is produced by a deep-learning model. The scale depends on the regulatory layer — see the formulas below so you can interpret <code>+0.3</code> correctly.</p><dl><dt>Per-layer effect</dt><dd>Unit depends on the layer:<ul><li><b>Promoter activity (MPRA)</b> <span class='formula-chip'>Δ (alt−ref)</span> — <code>alt − ref</code>. Raw difference in predicted value (not a ratio). Useful when ref is near zero.</li></ul></dd></dl></section>
 <h2>Promoter activity (MPRA) <span class="formula-chip">Δ (alt−ref)</span></h2>
 <table><thead><tr>
@@ -73,10 +73,10 @@ tr:hover td { background: #e9ecef; }
 <tr>
 <td>LentiMPRA:HepG2</td>
 <td>HepG2</td>
-<td>-0.0483</td>
-<td>0.251</td>
-<td class="bar-cell"><span class="bar bar-pos" style="width:100%"></span>+0.299</td>
-<td><span class="badge badge-moderate">Moderate activation</span></td>
+<td>0.371</td>
+<td>0.718</td>
+<td class="bar-cell"><span class="bar bar-pos" style="width:100%"></span>+0.347</td>
+<td><span class="badge badge-strong">Strong activation</span></td>
 </tr>
 </tbody></table>
 <h2>Interactive Genome Browser</h2>
@@ -157,7 +157,7 @@ function(e){var t,i,n,r,s,o,a,c,l,h,d,u,f,p,g,m,w,b,F,v="sizzle"+1*new Date,y=e.
     try {
         const browser = await igv.createBrowser(
             document.getElementById("igv-div"),
-            {"genome":"hg38","locus":"chr1:109274867-109275068","showRuler":true,"showNavigation":true,"showCenterGuide":true,"roi":[{"name":"Modification","color":"rgba(255, 0, 0, 0.12)","features":[{"chr":"chr1","start":109274967,"end":109274969}]}],"tracks":[{"name":"Modification: G>T","type":"annotation","displayMode":"EXPANDED","height":25,"color":"red","features":[{"chr":"chr1","start":109274967,"end":109274969,"name":"chr1:109,274,968 G>T"}]},{"name":"LentiMPRA:HepG2","type":"merged","height":80,"tracks":[{"type":"wig","name":"LentiMPRA:HepG2 ref","color":"rgb(180,180,180)","windowFunction":"max","min":-3.0,"max":3.0,"autoscale":false,"features":[{"chr":"chr1","start":109274843,"end":109274893,"value":0.2983},{"chr":"chr1","start":109274893,"end":109274943,"value":0.0679},{"chr":"chr1","start":109274943,"end":109274993,"value":-0.1181},{"chr":"chr1","start":109274993,"end":109275043,"value":0.0861},{"chr":"chr1","start":109275043,"end":109275093,"value":-0.5285}]},{"type":"wig","name":"LentiMPRA:HepG2 alt","color":"rgb(230,120,0)","windowFunction":"max","min":-3.0,"max":3.0,"autoscale":false,"features":[{"chr":"chr1","start":109274843,"end":109274893,"value":0.5774},{"chr":"chr1","start":109274893,"end":109274943,"value":0.4667},{"chr":"chr1","start":109274943,"end":109274993,"value":0.4061},{"chr":"chr1","start":109274993,"end":109275043,"value":0.0861},{"chr":"chr1","start":109275043,"end":109275093,"value":-0.5285}]}]}]}
+            {"genome":"hg38","locus":"chr1:109274867-109275067","showRuler":true,"showNavigation":true,"showCenterGuide":true,"roi":[{"name":"Modification","color":"rgba(255, 0, 0, 0.12)","features":[{"chr":"chr1","start":109274967,"end":109274969}]}],"tracks":[{"name":"Modification: G>T","type":"annotation","displayMode":"EXPANDED","height":25,"color":"red","features":[{"chr":"chr1","start":109274967,"end":109274969,"name":"chr1:109,274,968 G>T"}]},{"name":"LentiMPRA:HepG2","type":"merged","height":80,"tracks":[{"type":"wig","name":"LentiMPRA:HepG2 ref","color":"rgb(180,180,180)","windowFunction":"max","min":-3.0,"max":3.0,"autoscale":false,"features":[{"chr":"chr1","start":109274943,"end":109274993,"value":0.2983}]},{"type":"wig","name":"LentiMPRA:HepG2 alt","color":"rgb(230,120,0)","windowFunction":"max","min":-3.0,"max":3.0,"autoscale":false,"features":[{"chr":"chr1","start":109274943,"end":109274993,"value":0.5774}]}]}]}
         );
         console.log("IGV browser created successfully");
     } catch(e) {

--- a/scripts/regenerate_multioracle.py
+++ b/scripts/regenerate_multioracle.py
@@ -257,12 +257,13 @@ def run_legnet():
     from chorus.oracles.legnet import LegNetOracle
     oracle = LegNetOracle(cell_type="HepG2", assay="LentiMPRA")
     oracle.load_pretrained_model()
-    # LegNet is a 200 bp element-level model: score it on its native window
-    # centred on the variant (the conversational/Python path), not the 1 Mb
-    # default that would dilute the single-variant effect to ~0.
-    seqlen = int(getattr(oracle, "sequence_length", 200) or 200)
-    half = seqlen // 2
-    region = f"{VARIANT['chrom']}:{VARIANT['position'] - half}-{VARIANT['position'] + half}"
+    # LegNet is a 200 bp element-level model. Mirror the conversational/MCP path
+    # EXACTLY (server._auto_region passes a 1 bp region that base.py auto-widens to
+    # a single 200 bp window centred on the variant). A wider region tiles the
+    # model into several windows and averages the single-variant effect away, so
+    # the table value would not match what a user gets by asking conversationally.
+    pos = VARIANT["position"]
+    region = f"{VARIANT['chrom']}:{pos}-{pos + 1}"
     report = _build_variant_report(oracle, oracle_name="legnet", region=region)
     return _save_oracle_artefacts(report, "legnet")
 


### PR DESCRIPTION
Two small correctness fixes surfaced by a pre-publication audit of the [chorus-article](https://github.com/pinellolab/chorus-article) reproduction package.

### 1. MCP help text undercounted oracles
`list_oracles()` docstring said *"6 plus an alternative PyTorch backend"* and `getting_started()` said *"all 6 available oracles"* with a 6-item list **omitting EPInformer-seq**. The data path already returns 7; only the user-facing strings were stale (a leftover from before EPInformer-seq landed). Now says **7** and lists EPInformer-seq. This is what an agent/user sees first, and it contradicted the article's "seven oracles".

### 2. `run_legnet` now mirrors the conversational path exactly
`scripts/regenerate_multioracle.py` `run_legnet` scored LegNet on a `pos±100` (201 bp) region. LegNet's native window is 200 bp, so 201 bp tiled the model into **5 windows** and averaged the single-variant effect (**+0.347 → +0.299**). But the conversational/MCP path (`server._auto_region`) passes a **1 bp** region that `base.py` auto-widens to a **single 200 bp** window → **+0.347**. So the multi-oracle consensus table did not match what a user gets by asking conversationally.

Fix: `run_legnet` now passes the same 1 bp region. LegNet MPRA = **+0.347** (ref 0.371 → alt 0.718), matching `claims.yaml` A7 and the conversational path. ChromBPNet/AlphaGenome unchanged (already correct). Regenerated the committed multi-oracle example.

Follow-up to #94 (which fixed the larger 1 Mb-locus dilution for ChromBPNet/LegNet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)