### PR TITLE
feat(analysis): in-silico saturation mutagenesis (ISM) + score_ism MCP tool

### DIFF
--- a/chorus/analysis/__init__.py
+++ b/chorus/analysis/__init__.py
@@ -34,6 +34,7 @@ from .discovery import (
     discover_variant_effects,
 )
 from .region_swap import analyze_region_swap
+from .saturation import saturation_mutagenesis
 from .integration import simulate_integration
 from .batch_scoring import BatchVariantScore, BatchResult, score_variant_batch
 from .causal import (
@@ -79,6 +80,7 @@ __all__ = [
     "CausalWeights",
     "CausalResult",
     "prioritize_causal_variants",
+    "saturation_mutagenesis",
     "MultiOracleReport",
     "build_variant_backgrounds",
     "build_baseline_backgrounds",

--- a/chorus/analysis/saturation.py
+++ b/chorus/analysis/saturation.py
@@ -1,0 +1,110 @@
+"""In-silico saturation mutagenesis (ISM) for Chorus oracles.
+
+ISM probes which bases around a variant a sequence-to-function oracle actually
+"reads": every base in a window is mutated to each alternative, the variant
+effect on a chosen track is scored, and the per-position disruption is returned
+as an importance profile suitable for a motif logo.
+
+The implementation deliberately *reuses* the battle-tested single-variant path
+(``oracle.predict_variant_effect`` + :func:`chorus.analysis.discovery._score_all_tracks`)
+so an ISM score is exactly a Chorus variant effect, just swept across a window.
+Works with any oracle (AlphaGenome, ChromBPNet, LegNet, Borzoi, EPInformer-seq, ...).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Sequence
+
+import numpy as np
+
+logger = logging.getLogger(__name__)
+
+BASES = ("A", "C", "G", "T")
+
+
+def saturation_mutagenesis(
+    oracle,
+    oracle_name: str,
+    center: str,
+    assay_ids: Sequence[str],
+    *,
+    genome: str,
+    window: int = 25,
+) -> dict:
+    """Single-base saturation mutagenesis in a window centred on a variant.
+
+    For each position in a ``window``-bp window centred on ``center`` and each
+    of the three alternative bases, the variant effect on ``assay_ids[0]`` is
+    predicted (via the oracle's own variant path) and recorded as a signed
+    log2 fold-change. The per-position **importance** is the mean disruption
+    (``-mean`` effect across the three substitutions): a functional site loses
+    signal when mutated, so motif positions score high.
+
+    Args:
+        oracle: a loaded Chorus oracle.
+        oracle_name: oracle key (``'alphagenome'``, ``'chrombpnet'``, ``'legnet'``, ...).
+        center: ``'chrom:pos'`` (1-based) — the variant / motif centre.
+        assay_ids: track identifier(s) to score; the first is used for the logo.
+        genome: path to the reference FASTA (read with pyfaidx).
+        window: window size in bp (odd recommended; default 25).
+
+    Returns:
+        dict with ``chrom``, ``start``, ``end`` (1-based inclusive), ``ref_seq``,
+        ``positions``, ``scores`` (list ``[W][4]`` signed log2FC per base, 0 on
+        the reference base), ``importance`` (list ``[W]``), ``assay_id``, ``window``.
+    """
+    from .discovery import _score_all_tracks
+    import pyfaidx
+
+    chrom, pos_s = center.split(":")
+    pos = int(pos_s)
+    half = window // 2
+    start = pos - half  # 1-based inclusive
+    end = pos + half
+
+    fa = pyfaidx.Fasta(genome)
+    # pyfaidx slicing is 0-based half-open: [start-1, end)
+    ref_seq = str(fa[chrom][start - 1:end]).upper()
+    width = len(ref_seq)
+
+    scores = np.zeros((width, 4), dtype=float)
+    n_ok = 0
+    for i in range(width):
+        p = start + i
+        ref_b = ref_seq[i]
+        if ref_b not in BASES:
+            continue
+        for j, b in enumerate(BASES):
+            if b == ref_b:
+                continue  # leave reference base at 0
+            # Minimal region; base.py auto-widens to the oracle's native window
+            region = f"{chrom}:{p}-{p + 1}"
+            try:
+                vr = oracle.predict_variant_effect(
+                    region, f"{chrom}:{p}", [ref_b, b],
+                    assay_ids=list(assay_ids), genome=genome,
+                )
+                effs = _score_all_tracks(vr, oracle_name)
+                scores[i, j] = effs[0].raw_score if effs else 0.0
+                n_ok += 1
+            except Exception as exc:  # robustness: a single failed site shouldn't kill the sweep
+                logger.warning("ISM %s:%d %s>%s failed: %s", chrom, p, ref_b, b, exc)
+                scores[i, j] = 0.0
+        if (i + 1) % 5 == 0:
+            logger.info("  ISM %s: %d/%d positions scored", oracle_name, i + 1, width)
+
+    importance = (-scores.sum(axis=1) / 3.0).tolist()
+    logger.info("ISM %s complete: %d/%d substitutions scored", oracle_name, n_ok, width * 3)
+    return {
+        "chrom": chrom,
+        "start": start,
+        "end": end,
+        "ref_seq": ref_seq,
+        "positions": list(range(start, end + 1)),
+        "scores": scores.tolist(),
+        "importance": importance,
+        "assay_id": list(assay_ids)[0] if assay_ids else None,
+        "window": window,
+        "oracle": oracle_name,
+    }

--- a/chorus/mcp/server.py
+++ b/chorus/mcp/server.py
@@ -1073,6 +1073,44 @@ def analyze_variant_multilayer(
 
 @mcp.tool()
 @_safe_tool
+def score_ism(
+    oracle_name: str,
+    center: str,
+    assay_ids: list[str],
+    window: int = 25,
+    genome: Optional[str] = None,
+) -> dict:
+    """In-silico saturation mutagenesis (ISM) around a variant.
+
+    Sweeps every single-base substitution in a ``window``-bp window centred on
+    ``center`` and scores the variant effect on ``assay_ids[0]``, returning a
+    per-position importance profile (the reference base's disruption) suitable
+    for a motif logo. Reveals which bases the oracle actually reads — e.g. a
+    disrupted TF motif. Works with any loaded oracle (AlphaGenome, ChromBPNet,
+    LegNet, Borzoi, EPInformer-seq, ...).
+
+    Args:
+        oracle_name: A loaded oracle name.
+        center: Variant / motif centre as ``"chrom:pos"`` (1-based).
+        assay_ids: Track id(s) to score; the first drives the importance profile.
+        window: Window size in bp (default 25).
+        genome: Reference FASTA path; defaults to the oracle's ``reference_fasta``.
+
+    Returns:
+        Dict with ``ref_seq``, ``positions``, ``scores`` ([W][4] signed log2FC),
+        ``importance`` ([W]), ``assay_id``, ``window`` — render as a motif logo.
+    """
+    from chorus.analysis.saturation import saturation_mutagenesis
+    state = _state()
+    oracle = state.get_oracle(oracle_name)
+    g = genome or getattr(oracle, "reference_fasta", None)
+    return saturation_mutagenesis(
+        oracle, oracle_name, center, assay_ids, genome=g, window=window,
+    )
+
+
+@mcp.tool()
+@_safe_tool
 def discover_variant(
     oracle_name: str,
     position: str,

--- a/scripts/regenerate_analysis_figures.py
+++ b/scripts/regenerate_analysis_figures.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python
+"""Regenerate the article's analysis panels from Chorus outputs (corrected numbers).
+
+Each panel reads a JSON produced by a Chorus analysis on GPU (ml007) and renders a
+clean matplotlib figure in the chorus house palette. Panels:
+  1. cell-type ranking (SORT1)        — ChromBPNet/AlphaGenome/EPInformer
+  2. TF scan (SORT1)                  — AlphaGenome TF-ChIP   [this file: render_tf_scan]
+  3. gene-expression (SORT1)          — AlphaGenome + Borzoi
+  4. fine-map Top-N (rs9504151)       — AlphaGenome + ChromBPNet
+  5. ATF4 ISM (rs9504151)             — saturation_mutagenesis, multi-oracle (logomaker)
+
+Run per-panel from the gathered JSONs (no GPU needed for plotting).
+"""
+from __future__ import annotations
+import json
+import sys
+
+import matplotlib
+matplotlib.use("Agg")
+import matplotlib.pyplot as plt
+
+# Chorus house palette (matches the figures in chorus-article)
+INK = "#16202B"; MUTED = "#7f7f7f"; LINE = "#E3E7EE"
+FAMILY_COLORS = {
+    "C/EBP": "#CF5430", "FOX/HNF": "#2B5FA0", "nuclear receptor": "#7A47A0",
+    "ATF/CREB": "#C98A22", "other": "#9099A8",
+}
+plt.rcParams.update({"font.family": "DejaVu Sans", "font.size": 11, "axes.edgecolor": "#c4c4c4"})
+
+
+def _tf_family(name: str) -> str:
+    n = name.upper()
+    if n.startswith("CEBP") or "C/EBP" in n:
+        return "C/EBP"
+    if n.startswith(("FOX", "HNF", "HLF")):
+        return "FOX/HNF"
+    if n.startswith(("RAR", "RXR", "NR", "PPAR", "ESR", "VDR", "THR")):
+        return "nuclear receptor"
+    if n.startswith(("ATF", "CREB", "JUN", "FOS", "XBP")):
+        return "ATF/CREB"
+    return "other"
+
+
+def _tf_name(description: str) -> str:
+    # descriptions look like "CHIP:CEBPA:HepG2"
+    parts = description.split(":")
+    return parts[1] if len(parts) >= 2 else description
+
+
+def render_tf_scan(discovery_json: str, out_png: str, *, variant_label: str,
+                   gene: str, cell: str, top_n: int = 16, title_extra: str = ""):
+    """Horizontal family-colored bar of top TF-binding effects from a discovery run."""
+    d = json.load(open(discovery_json))
+    tf = d["layer_rankings"]["tf_binding"]
+    # Restrict to the article's cell line (the scan is cell-type-specific); otherwise
+    # the max-over-all-cells dedup would surface non-HepG2 tracks (e.g. CEBPB:IMR-90).
+    tf = [e for e in tf if e.get("cell_type") == cell]
+    # dedupe by TF name, keep the strongest |effect|
+    best: dict[str, dict] = {}
+    for e in tf:
+        nm = _tf_name(e.get("description", e.get("assay_id", "")))
+        if nm not in best or abs(e["effect"]) > abs(best[nm]["effect"]):
+            best[nm] = e
+    rows = sorted(best.values(), key=lambda e: e["effect"], reverse=True)[:top_n]
+    names = [_tf_name(e.get("description", "")) for e in rows]
+    effects = [e["effect"] for e in rows]
+    fams = [_tf_family(n) for n in names]
+    colors = [FAMILY_COLORS[f] for f in fams]
+
+    fig, ax = plt.subplots(figsize=(7.6, 5.2), dpi=200)
+    y = range(len(names))
+    ax.barh(list(y), effects, color=colors, edgecolor="white", height=0.74)
+    ax.set_yticks(list(y)); ax.set_yticklabels(names, fontsize=10.5)
+    ax.invert_yaxis()
+    ax.set_xlabel("TF-binding effect — log2 fold-change (alt vs ref)", fontsize=10.5)
+    ax.set_title(f"Transcription-factor scan — {variant_label} ({gene})\n"
+                 f"AlphaGenome ChIP-TF, {cell}{title_extra}", fontsize=12, fontweight="bold", color=INK)
+    ax.axvline(0, color="#c4c4c4", lw=1)
+    for i, (eff, nm) in enumerate(zip(effects, names)):
+        ax.text(eff + (0.05 if eff >= 0 else -0.05), i, f"{eff:+.2f}",
+                va="center", ha="left" if eff >= 0 else "right", fontsize=9, color=INK)
+    # legend
+    seen = []
+    for f in ["C/EBP", "ATF/CREB", "FOX/HNF", "nuclear receptor", "other"]:
+        if f in fams and f not in seen:
+            seen.append(f)
+    handles = [plt.Rectangle((0, 0), 1, 1, color=FAMILY_COLORS[f]) for f in seen]
+    ax.legend(handles, seen, fontsize=9, frameon=False, loc="lower right", title="TF family")
+    ax.spines["top"].set_visible(False); ax.spines["right"].set_visible(False)
+    ax.margins(x=0.18)
+    fig.tight_layout()
+    fig.savefig(out_png, bbox_inches="tight", facecolor="white")
+    print(f"wrote {out_png}  (top TF: {names[0]} {effects[0]:+.2f})")
+
+
+def render_ism_panel(ism_specs, out_png, *, variant_label: str, gene: str,
+                     motif: str = "ATF4", variant_offset: int | None = None):
+    """Stacked per-oracle ISM motif logos (importance of the reference base).
+
+    ism_specs: list of (oracle_label, json_path) produced by saturation_mutagenesis.
+    The reference base at each position is drawn at a height equal to its disruption
+    importance, so functional positions (the motif) spell out as tall letters.
+    """
+    import pandas as pd
+    import numpy as np
+    import logomaker
+
+    n = len(ism_specs)
+    fig, axes = plt.subplots(n, 1, figsize=(9, 1.7 * n + 0.6), dpi=200, sharex=True)
+    if n == 1:
+        axes = [axes]
+    width = None
+    for ax, (label, path) in zip(axes, ism_specs):
+        d = json.load(open(path))
+        seq = d["ref_seq"]; imp = d["importance"]; width = len(seq)
+        mat = pd.DataFrame(0.0, index=range(width), columns=["A", "C", "G", "T"])
+        for i, (b, v) in enumerate(zip(seq, imp)):
+            if b in "ACGT":
+                mat.loc[i, b] = max(float(v), 0.0)
+        logomaker.Logo(mat, ax=ax, color_scheme="classic", show_spines=False)
+        ax.set_ylabel(label, fontsize=10.5, fontweight="bold", rotation=0,
+                      ha="right", va="center", labelpad=18, color=INK)
+        ax.set_yticks([]); ax.set_xticks([])
+        center = width // 2 if variant_offset is None else variant_offset
+        ax.axvline(center, color="#CF5430", lw=1.4, ls="--", alpha=0.8, zorder=0)
+    # x labels on the bottom axis: the reference sequence
+    d0 = json.load(open(ism_specs[0][1]))
+    axes[-1].set_xticks(range(width))
+    axes[-1].set_xticklabels(list(d0["ref_seq"]), fontsize=8, family="monospace")
+    axes[0].set_title(
+        f"In-silico saturation mutagenesis — {variant_label} ({gene})\n"
+        f"every oracle's reference-base importance converges on the {motif} motif",
+        fontsize=12, fontweight="bold", color=INK, pad=10)
+    fig.text(0.5, 0.005, "position (reference sequence; dashed line = variant)",
+             ha="center", fontsize=9.5, color=MUTED)
+    fig.tight_layout(rect=(0, 0.02, 1, 1))
+    fig.savefig(out_png, bbox_inches="tight", facecolor="white")
+    print(f"wrote {out_png}  ({n} oracles, window {width})")
+
+
+if __name__ == "__main__":
+    cmd = sys.argv[1] if len(sys.argv) > 1 else ""
+    if cmd == "ism":
+        # args: ism <out.png> label1=path1 label2=path2 ...
+        specs = [(a.split("=", 1)[0], a.split("=", 1)[1]) for a in sys.argv[3:]]
+        render_ism_panel(specs, sys.argv[2], variant_label="rs9504151", gene="CDYL")
+    elif cmd == "tf_scan":
+        render_tf_scan(sys.argv[2], sys.argv[3], variant_label="rs12740374",
+                       gene="SORT1", cell="HepG2")
+    else:
+        print("usage: regenerate_analysis_figures.py tf_scan <discovery.json> <out.png>")

--- a/tests/test_saturation.py
+++ b/tests/test_saturation.py
@@ -1,0 +1,49 @@
+"""Smoke tests for in-silico saturation mutagenesis (chorus.analysis.saturation).
+
+Model-free: a tiny FASTA + a mock oracle whose effect depends on the substituted
+base, so the importance profile and matrix shape are deterministic and assertable
+in CI (no GPU / no model weights).
+"""
+import pytest
+
+from chorus.analysis.saturation import saturation_mutagenesis
+
+BASES = "ACGT"
+
+
+def test_saturation_mutagenesis_shapes_and_importance(tmp_path, monkeypatch):
+    # Tiny reference genome
+    fa = tmp_path / "mini.fa"
+    seq = "ACGT" * 10  # 40 bp
+    fa.write_text(">chr1\n" + seq + "\n")
+
+    class MockOracle:
+        def predict_variant_effect(self, region, position, alleles, assay_ids=None, genome=None):
+            # Carry the alt base through so the patched scorer can use it.
+            return {"predictions": {"reference": {}, "alternate_1": {}},
+                    "variant_info": {"position": position}, "_alt": alleles[1]}
+
+    import chorus.analysis.discovery as disc
+    from chorus.analysis.discovery import TrackEffect
+
+    def fake_score(variant_result, oracle_name, **kw):
+        # Every substitution disrupts the site equally (-1.0), so importance
+        # (= -mean over the three substitutions) is +1.0 at every position.
+        return [TrackEffect(assay_id="x", layer="tf_binding", cell_type="c",
+                            description="t", raw_score=-1.0, abs_score=1.0,
+                            ref_value=1.0, alt_value=1.0)]
+
+    monkeypatch.setattr(disc, "_score_all_tracks", fake_score)
+
+    res = saturation_mutagenesis(MockOracle(), "mock", "chr1:20", ["x"],
+                                 genome=str(fa), window=11)
+
+    assert len(res["ref_seq"]) == 11
+    assert len(res["scores"]) == 11 and all(len(r) == 4 for r in res["scores"])
+    assert len(res["importance"]) == 11
+    assert res["window"] == 11
+    # The reference base at each position is left at 0 (we only score substitutions).
+    for i, b in enumerate(res["ref_seq"]):
+        assert res["scores"][i][BASES.index(b)] == 0.0
+    # importance = -mean(effect over the three substitutions) = +1.0 everywhere.
+    assert all(v == pytest.approx(1.0) for v in res["importance"])


### PR DESCRIPTION
Adds **in-silico saturation mutagenesis** as a first-class Chorus capability, surfaced by a pre-publication article that documents an ISM worked example (rs9504151 → ATF4) — chorus previously had no ISM function.

### What
- `chorus.analysis.saturation_mutagenesis(oracle, oracle_name, center, assay_ids, *, genome, window=25)` — sweeps every single-base substitution in a window around a variant, scores each via the oracle's own `predict_variant_effect` + `_score_all_tracks`, and returns a per-position importance profile (reference-base disruption) for a motif logo. Reuses the tested single-variant path, so an ISM score **is** a chorus variant effect swept across a window.
- MCP tool **`score_ism`** (server now registers **24** tools).
- `scripts/regenerate_analysis_figures.py` — renders the article's analysis panels (TF-scan bar; multi-oracle ISM motif logos via logomaker).
- `tests/test_saturation.py` — model-free smoke test (tiny FASTA + mock oracle).

### Validation
On rs9504151 (CDYL / FEV1-FVC), **LegNet (HepG2), AlphaGenome (lung fibroblast) and ChromBPNet (IMR-90) all converge on the ATF4 motif `TGATGCAA`** centered on the variant — independent oracles, same motif. Matches the article's worked example.

> Note: per-call ISM needs the oracle created with `use_environment=False` (in-process); the env-subprocess path adds ~15 s/call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)