### PR TITLE
fix(variant_report): LAYER_CONFIGS UnboundLocalError crashed fine-mapping / multilayer

### DIFF
--- a/chorus/analysis/variant_report.py
+++ b/chorus/analysis/variant_report.py
@@ -1104,7 +1104,12 @@ def build_variant_report(
             # = 4 bins). DNase/ATAC/CAGE/PROCAP at 1 bp/bin and AG histone
             # at 2001 bp / 128 bp = 15 bins are both safe.
             low_bins = False
-            from .scorers import LAYER_CONFIGS
+            # NB: LAYER_CONFIGS is imported at module scope (top of file). A
+            # function-local re-import here would make Python treat LAYER_CONFIGS
+            # as a local for the whole function, raising UnboundLocalError at its
+            # earlier use (the per-gene TSS block) — which crashes
+            # fine_map_causal_variant / analyze_variant_multilayer on any CAGE
+            # track with a nearby gene.
             cfg = LAYER_CONFIGS.get(layer)
             if cfg is not None and cfg.window_bp is not None:
                 res = getattr(ref_track, "resolution", 1) or 1

--- a/tests/test_variant_report_regression.py
+++ b/tests/test_variant_report_regression.py
@@ -1,0 +1,20 @@
+"""Regression guards for chorus.analysis.variant_report."""
+import inspect
+
+from chorus.analysis import variant_report
+
+
+def test_build_variant_report_no_local_layer_configs_shadow():
+    """`build_variant_report` must NOT re-import LAYER_CONFIGS function-locally.
+
+    LAYER_CONFIGS is imported at module scope. A function-local
+    `from .scorers import LAYER_CONFIGS` makes Python treat the name as a local
+    for the whole function, so its *earlier* use (the per-gene TSS block) raises
+    UnboundLocalError — which crashed fine_map_causal_variant /
+    analyze_variant_multilayer on any CAGE track with a nearby gene.
+    """
+    src = inspect.getsource(variant_report.build_variant_report)
+    assert "import LAYER_CONFIGS" not in src, (
+        "function-local LAYER_CONFIGS import shadows the module-level one "
+        "(UnboundLocalError on the CAGE + nearby-gene path)"
+    )


### PR DESCRIPTION
## Bug (P0)
`build_variant_report` re-imported `LAYER_CONFIGS` function-locally (`from .scorers import LAYER_CONFIGS`) even though it's imported at module scope. Python then treats `LAYER_CONFIGS` as a **local** for the entire function, so its *earlier* use in the per-gene TSS block raises:

```
UnboundLocalError: cannot access local variable 'LAYER_CONFIGS' ... variant_report.py:1060
```

This crashes **`fine_map_causal_variant`** and **`analyze_variant_multilayer`** on AlphaGenome whenever a CAGE / `tss_activity` track with a nearby gene is in scope — i.e. the article's headline conversational path (Analysis B fine-map of rs9504151 failed on all 56 variants).

## How it was found
An independent, context-isolated reproduction review of the [chorus-article](https://github.com/pinellolab/chorus-article) worked examples: every scientific value reproduced, but the **documented fine-map path crashed** (the value was only obtainable by avoiding CAGE tracks). Per the repro contract, "a number that only reproduces with a workaround is a finding."

## Fix
Drop the redundant local import (one line). Verified on an A100 box: `build_variant_report(CAGE track + gene=SORT1)` and the all-track AlphaGenome fine-map of rs9504151 now run without crashing (rs9504151 still ranks #1, rs62384944 → rank 4). Adds a static regression guard (`tests/test_variant_report_regression.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)