### PR TITLE
perf(alphagenome): persistent worker for env-isolated fine-map (~38× faster, load model once)

### DIFF
--- a/chorus/analysis/causal.py
+++ b/chorus/analysis/causal.py
@@ -6,6 +6,7 @@ rewards convergent multi-layer evidence.
 """
 
 import base64
+import contextlib
 import io
 import logging
 import math
@@ -471,133 +472,144 @@ def prioritize_causal_variants(
     nearby_genes: list[str] = []
     cell_types: set[str] = set()
 
-    for i, ldv in enumerate(ld_variants):
-        _orient_to_genome(ldv)
-        logger.info(
-            "Scoring variant %d/%d: %s (r²=%.2f)",
-            i + 1, len(ld_variants), ldv.variant_id, ldv.r2,
-        )
-
-        try:
-            position = f"{ldv.chrom}:{ldv.position}"
-            region = _scoring_region(oracle, ldv.chrom, ldv.position)
-
-            variant_result = oracle.predict_variant_effect(
-                genomic_region=region,
-                variant_position=position,
-                alleles=[ldv.ref, ldv.alt],
-                assay_ids=assay_ids,
+    # Amortise model-load across every forward pass in this fine-map.
+    # AlphaGenome (use_environment=True) spawns + reloads the model per
+    # forward pass otherwise; predict_session() keeps ONE worker alive for
+    # the whole loop AND the top-N rebuild below (byte-identical scores).
+    # Other oracles have no predict_session -> nullcontext (a no-op).
+    session = (
+        oracle.predict_session()
+        if hasattr(oracle, "predict_session")
+        else contextlib.nullcontext()
+    )
+    with session:
+        for i, ldv in enumerate(ld_variants):
+            _orient_to_genome(ldv)
+            logger.info(
+                "Scoring variant %d/%d: %s (r²=%.2f)",
+                i + 1, len(ld_variants), ldv.variant_id, ldv.r2,
             )
 
-            # Score with the lightweight report path: identical per-track
-            # allele_scores, but skips the per-variant IGV signal-array
-            # assembly that the ranking never reads. Full reports (with IGV)
-            # are rebuilt below only for the top `report_top_n` variants.
-            # We deliberately do NOT cache the per-variant ``variant_result``:
-            # each AlphaGenome prediction is ~5000 tracks × ~8k bins × alleles,
-            # so retaining all proxies' predictions would cost tens of GB. The
-            # top-N pass re-predicts those few variants instead (a handful of
-            # forward passes) to rebuild full reports with IGV tracks.
-            report = build_variant_report(
-                variant_result,
-                oracle_name=oracle_name,
-                gene_name=gene_name,
-                normalizer=normalizer,
-                lightweight=True,
-            )
-
-            # Capture nearby genes from first report
-            if not nearby_genes and report.nearby_genes:
-                nearby_genes = report.nearby_genes
-            # Record ONLY the cell type of each variant's strongest-effect
-            # track — collecting all 600+ cell types scored per variant
-            # would make the rendered report unreadable.
-            _best_abs = 0.0
-            _best_ct = ""
-            for allele_scores in report.allele_scores.values():
-                for ts in allele_scores:
-                    if ts.raw_score is None:
-                        continue
-                    if abs(ts.raw_score) > _best_abs:
-                        _best_abs = abs(ts.raw_score)
-                        _best_ct = ts.cell_type or ""
-            if _best_ct:
-                cell_types.add(_best_ct)
-
-            # Extract per-layer scores
-            cs = _extract_component_scores(ldv, report, weights)
-            raw_scores.append(cs)
-
-        except Exception as exc:
-            logger.error("Failed to score %s: %s", ldv.variant_id, exc, exc_info=True)
-            raw_scores.append(CausalVariantScore(
-                variant_id=ldv.variant_id,
-                chrom=ldv.chrom,
-                position=ldv.position,
-                ref=ldv.ref,
-                alt=ldv.alt,
-                r2=ldv.r2,
-                is_sentinel=ldv.is_sentinel,
-                kind=getattr(ldv, "kind", "snv"),
-                max_effect=0.0,
-                n_layers_affected=0,
-                convergence_score=0.0,
-                ref_activity=0.0,
-                composite=0.0,
-                top_layer="error",
-                top_track=str(exc),
-            ))
-
-    # Compute composite scores with min-max normalization
-    _compute_composites(raw_scores, weights)
-
-    # Sort by composite descending
-    raw_scores.sort(key=lambda s: s.composite, reverse=True)
-
-    # Build the FULL report (with IGV signal tracks) only for the top
-    # `report_top_n` variants — the scoring loop above used the lightweight
-    # path (identical per-track scores, no IGV payload) so the IGV browser
-    # in the HTML report would otherwise have no signal tracks at all. We
-    # re-predict each of those few variants (one forward pass each) and
-    # rebuild a full report, attaching it to ``_variant_report``. Only
-    # variants that scored non-zero in ≥1 track are eligible (a variant with
-    # all-zero effects has nothing to plot); fewer than `report_top_n` are
-    # built when fewer qualify. Per-track scores are NOT recomputed into the
-    # ranking — the lightweight scores already drove it — so the ranking is
-    # unaffected by this pass.
-    if report_top_n > 0:
-        n_built = 0
-        for cs in raw_scores:
-            if n_built >= report_top_n:
-                break
-            # Skip error rows and variants with no scorable effect.
-            nonzero = any(
-                ts.raw_score is not None and ts.raw_score != 0.0
-                for ts in cs.track_scores.values()
-            )
-            if not nonzero:
-                continue
             try:
-                full_vr = oracle.predict_variant_effect(
-                    genomic_region=_scoring_region(oracle, cs.chrom, cs.position),
-                    variant_position=f"{cs.chrom}:{cs.position}",
-                    alleles=[cs.ref, cs.alt],
+                position = f"{ldv.chrom}:{ldv.position}"
+                region = _scoring_region(oracle, ldv.chrom, ldv.position)
+
+                variant_result = oracle.predict_variant_effect(
+                    genomic_region=region,
+                    variant_position=position,
+                    alleles=[ldv.ref, ldv.alt],
                     assay_ids=assay_ids,
                 )
-                full_report = build_variant_report(
-                    full_vr,
+
+                # Score with the lightweight report path: identical per-track
+                # allele_scores, but skips the per-variant IGV signal-array
+                # assembly that the ranking never reads. Full reports (with IGV)
+                # are rebuilt below only for the top `report_top_n` variants.
+                # We deliberately do NOT cache the per-variant ``variant_result``:
+                # each AlphaGenome prediction is ~5000 tracks × ~8k bins × alleles,
+                # so retaining all proxies' predictions would cost tens of GB. The
+                # top-N pass re-predicts those few variants instead (a handful of
+                # forward passes) to rebuild full reports with IGV tracks.
+                report = build_variant_report(
+                    variant_result,
                     oracle_name=oracle_name,
                     gene_name=gene_name,
                     normalizer=normalizer,
-                    lightweight=False,
+                    lightweight=True,
                 )
-                cs._variant_report = full_report
-                n_built += 1
-            except Exception as exc:  # pragma: no cover - best-effort IGV
-                logger.warning(
-                    "Could not build full report for top variant %s: %s",
-                    cs.variant_id, exc,
+
+                # Capture nearby genes from first report
+                if not nearby_genes and report.nearby_genes:
+                    nearby_genes = report.nearby_genes
+                # Record ONLY the cell type of each variant's strongest-effect
+                # track — collecting all 600+ cell types scored per variant
+                # would make the rendered report unreadable.
+                _best_abs = 0.0
+                _best_ct = ""
+                for allele_scores in report.allele_scores.values():
+                    for ts in allele_scores:
+                        if ts.raw_score is None:
+                            continue
+                        if abs(ts.raw_score) > _best_abs:
+                            _best_abs = abs(ts.raw_score)
+                            _best_ct = ts.cell_type or ""
+                if _best_ct:
+                    cell_types.add(_best_ct)
+
+                # Extract per-layer scores
+                cs = _extract_component_scores(ldv, report, weights)
+                raw_scores.append(cs)
+
+            except Exception as exc:
+                logger.error("Failed to score %s: %s", ldv.variant_id, exc, exc_info=True)
+                raw_scores.append(CausalVariantScore(
+                    variant_id=ldv.variant_id,
+                    chrom=ldv.chrom,
+                    position=ldv.position,
+                    ref=ldv.ref,
+                    alt=ldv.alt,
+                    r2=ldv.r2,
+                    is_sentinel=ldv.is_sentinel,
+                    kind=getattr(ldv, "kind", "snv"),
+                    max_effect=0.0,
+                    n_layers_affected=0,
+                    convergence_score=0.0,
+                    ref_activity=0.0,
+                    composite=0.0,
+                    top_layer="error",
+                    top_track=str(exc),
+                ))
+
+        # Compute composite scores with min-max normalization
+        _compute_composites(raw_scores, weights)
+
+        # Sort by composite descending
+        raw_scores.sort(key=lambda s: s.composite, reverse=True)
+
+        # Build the FULL report (with IGV signal tracks) only for the top
+        # `report_top_n` variants — the scoring loop above used the lightweight
+        # path (identical per-track scores, no IGV payload) so the IGV browser
+        # in the HTML report would otherwise have no signal tracks at all. We
+        # re-predict each of those few variants (one forward pass each) and
+        # rebuild a full report, attaching it to ``_variant_report``. Only
+        # variants that scored non-zero in ≥1 track are eligible (a variant with
+        # all-zero effects has nothing to plot); fewer than `report_top_n` are
+        # built when fewer qualify. Per-track scores are NOT recomputed into the
+        # ranking — the lightweight scores already drove it — so the ranking is
+        # unaffected by this pass.
+        if report_top_n > 0:
+            n_built = 0
+            for cs in raw_scores:
+                if n_built >= report_top_n:
+                    break
+                # Skip error rows and variants with no scorable effect.
+                nonzero = any(
+                    ts.raw_score is not None and ts.raw_score != 0.0
+                    for ts in cs.track_scores.values()
                 )
+                if not nonzero:
+                    continue
+                try:
+                    full_vr = oracle.predict_variant_effect(
+                        genomic_region=_scoring_region(oracle, cs.chrom, cs.position),
+                        variant_position=f"{cs.chrom}:{cs.position}",
+                        alleles=[cs.ref, cs.alt],
+                        assay_ids=assay_ids,
+                    )
+                    full_report = build_variant_report(
+                        full_vr,
+                        oracle_name=oracle_name,
+                        gene_name=gene_name,
+                        normalizer=normalizer,
+                        lightweight=False,
+                    )
+                    cs._variant_report = full_report
+                    n_built += 1
+                except Exception as exc:  # pragma: no cover - best-effort IGV
+                    logger.warning(
+                        "Could not build full report for top variant %s: %s",
+                        cs.variant_id, exc,
+                    )
 
     # Ensure every CausalResult carries provenance metadata
     if analysis_request is None:

--- a/chorus/oracles/alphagenome.py
+++ b/chorus/oracles/alphagenome.py
@@ -7,6 +7,7 @@ from ..core.interval import Interval, GenomeRef, Sequence
 from ..core.exceptions import ModelNotLoadedError
 
 from typing import List, Tuple, Union, Optional, Dict, Any
+import contextlib
 import os
 import logging
 import json
@@ -58,6 +59,11 @@ class AlphaGenomeOracle(OracleBase):
         # Model state
         self._model = None
         self._track_dict = None
+        # Optional persistent prediction worker (use_environment only).
+        # When set via ``predict_session()``, _predict_in_environment
+        # routes through it instead of spawning a fresh subprocess per
+        # forward pass (load-once, serve-many). None == legacy path.
+        self._predict_worker = None
 
         # Reference genome
         self.reference_fasta = reference_fasta
@@ -87,6 +93,13 @@ class AlphaGenomeOracle(OracleBase):
         path = os.path.join(self.get_templates_dir(), "predict_template.py")
         with open(path) as inp:
             return inp.read(), "__ARGS_FILE_NAME__"
+
+    def get_predict_worker_template(self) -> Tuple[str, str]:
+        path = os.path.join(
+            self.get_templates_dir(), "predict_worker_template.py"
+        )
+        with open(path) as inp:
+            return inp.read(), "__INIT_ARGS_FILE__"
 
     # ------------------------------------------------------------------
     # Model loading
@@ -348,6 +361,12 @@ class AlphaGenomeOracle(OracleBase):
     def _predict_in_environment(
         self, seq: str, assay_ids: List[str]
     ) -> dict:
+        # Fast path: if a persistent worker session is active, serve the
+        # forward pass through it (model already loaded). Returns the same
+        # {"values": [...], "resolutions": [...]} dict as the spawn path.
+        worker = getattr(self, "_predict_worker", None)
+        if worker is not None:
+            return worker.predict(seq, assay_ids)
         args = {
             "device": self.device,
             "fold": self.fold,
@@ -372,6 +391,38 @@ class AlphaGenomeOracle(OracleBase):
         finally:
             os.unlink(arg_file.name)
         return result
+
+    @contextlib.contextmanager
+    def predict_session(self):
+        """Context manager that keeps a single AlphaGenome model loaded
+        across many forward passes.
+
+        Inside the ``with`` block, every ``_predict_in_environment`` call
+        is served by ONE long-lived ``chorus-alphagenome`` subprocess that
+        loaded the model (and fetched the ~330 MB GCS reference tables)
+        exactly once — instead of spawning a fresh subprocess (and
+        reloading everything) per call. Scores are byte-identical; this is
+        purely an amortisation of the model-load cost across a batch (e.g.
+        the per-variant scoring loop of a credible-set fine-map).
+
+        No-ops in two cases, yielding ``self`` unchanged:
+          * ``use_environment=False`` — the in-process model is already
+            loaded once and reused; there is no subprocess to amortise.
+          * a session is already active — reentrant; the existing worker
+            keeps serving (no second worker is spawned, and the inner
+            block does NOT tear the outer one down).
+        """
+        if not self.use_environment or self._predict_worker is not None:
+            # In-process (already fast) or reentrant — nothing to set up.
+            yield self
+            return
+        worker = AlphaGenomePredictWorker(self)
+        self._predict_worker = worker
+        try:
+            yield self
+        finally:
+            self._predict_worker = None
+            worker.close()
 
     def _predict_direct(self, seq: str, assay_ids: List[str]) -> dict:
         from .alphagenome_source.alphagenome_metadata import (
@@ -586,3 +637,286 @@ class AlphaGenomeOracle(OracleBase):
         if self.use_environment:
             status["environment_info"] = self.get_environment_info()
         return status
+
+
+class AlphaGenomePredictWorker:
+    """Long-lived ``chorus-alphagenome`` subprocess that loads the AlphaGenome
+    model once and serves many forward passes over stdin/stdout.
+
+    Replaces the spawn-a-subprocess-per-forward-pass cost of
+    :meth:`AlphaGenomeOracle._predict_in_environment` for batch workloads
+    (notably credible-set fine-mapping). Driven via
+    :meth:`AlphaGenomeOracle.predict_session`. Per-track ``values`` are
+    byte-identical to the per-call path: the worker template reuses the exact
+    per-assay extraction code from ``predict_template.py``.
+
+    Only short control lines (``READY`` / ``OK <path>`` / ``ERR ...``) cross
+    the stdout pipe; request args and result payloads travel through temp
+    files, so large ndarray payloads never risk a pipe-buffer deadlock.
+    """
+
+    # Generous: cold model load + GCS table fetch can take minutes.
+    DEFAULT_READY_TIMEOUT = 1800
+
+    def __init__(self, oracle: "AlphaGenomeOracle", ready_timeout: Optional[int] = None):
+        import subprocess
+        import tempfile
+
+        self._oracle = oracle
+        self._proc = None
+        self._closed = False
+        self._stderr_tail: List[str] = []
+
+        ready_timeout = ready_timeout or self.DEFAULT_READY_TIMEOUT
+
+        runner = oracle._env_runner
+        if runner is None:
+            raise RuntimeError(
+                "AlphaGenomePredictWorker requires use_environment=True "
+                "(no environment runner attached)."
+            )
+        env_manager = runner.env_manager
+        oracle_name = oracle.oracle_name
+
+        if not env_manager.environment_exists(oracle_name):
+            raise RuntimeError(
+                f"Environment for {oracle_name} does not exist. Run setup first."
+            )
+
+        python_exe = env_manager.get_python_executable(oracle_name)
+        if not python_exe:
+            raise RuntimeError(
+                f"Could not find Python executable for {oracle_name}"
+            )
+
+        # Init args (device/fold/length) written once to a temp JSON the
+        # worker reads at startup. Mirrors the per-call template's args file.
+        init_args = {
+            "device": oracle.device,
+            "fold": oracle.fold,
+            "length": oracle.sequence_length,
+        }
+        fd_init, self._init_args_path = tempfile.mkstemp(
+            suffix=".json", prefix="ag_worker_init_"
+        )
+        with os.fdopen(fd_init, "w") as fh:
+            json.dump(init_args, fh)
+
+        # Build worker code: substitute the init-args path, then prepend the
+        # chorus sys.path insert EXACTLY like the runner's wrappers do so the
+        # subprocess can import the chorus package.
+        template, placeholder = oracle.get_predict_worker_template()
+        code = template.replace(placeholder, self._init_args_path)
+
+        import chorus as _chorus
+        chorus_path = os.path.dirname(os.path.dirname(_chorus.__file__))
+        code = (
+            "import sys\n"
+            f"sys.path.insert(0, {chorus_path!r})\n"
+            + code
+        )
+
+        env = runner._prepare_env(oracle_name)
+
+        try:
+            self._proc = subprocess.Popen(
+                [python_exe, "-u", "-c", code],
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                text=True,
+                env=env,
+            )
+        except Exception:
+            self._cleanup_init_file()
+            raise
+
+        # Drain stderr on a background thread so the worker never blocks on a
+        # full stderr pipe during the (chatty) model load, and so we always
+        # have a tail to surface on failure.
+        import threading
+
+        # Optional: tee drained stderr to a file for debugging /
+        # verification (e.g. confirming the model loads exactly once).
+        # Off unless CHORUS_AG_WORKER_STDERR_LOG is set; no score impact.
+        stderr_log = os.environ.get("CHORUS_AG_WORKER_STDERR_LOG")
+
+        def _drain_stderr(proc, sink):
+            log_fh = None
+            if stderr_log:
+                try:
+                    log_fh = open(stderr_log, "a")
+                except OSError:
+                    log_fh = None
+            try:
+                for line in proc.stderr:
+                    sink.append(line.rstrip("\n"))
+                    if len(sink) > 200:
+                        del sink[:-200]
+                    if log_fh is not None:
+                        log_fh.write(line)
+                        log_fh.flush()
+            except Exception:
+                pass
+            finally:
+                if log_fh is not None:
+                    try:
+                        log_fh.close()
+                    except Exception:
+                        pass
+
+        self._stderr_thread = threading.Thread(
+            target=_drain_stderr, args=(self._proc, self._stderr_tail), daemon=True
+        )
+        self._stderr_thread.start()
+
+        try:
+            self._await_ready(ready_timeout)
+        except Exception:
+            self.close()
+            raise
+
+    # ------------------------------------------------------------------
+    def _stderr_tail_str(self, n: int = 40) -> str:
+        return "\n".join(self._stderr_tail[-n:])
+
+    def _await_ready(self, timeout: int) -> None:
+        """Block until the worker prints READY, or raise with stderr tail."""
+        import threading
+
+        result: Dict[str, Any] = {}
+
+        def _reader():
+            try:
+                result["line"] = self._proc.stdout.readline()
+            except Exception as exc:  # pragma: no cover - defensive
+                result["exc"] = exc
+
+        t = threading.Thread(target=_reader, daemon=True)
+        t.start()
+        t.join(timeout)
+        if t.is_alive():
+            self.close()
+            raise RuntimeError(
+                f"AlphaGenome worker did not become READY within {timeout}s. "
+                f"Stderr tail:\n{self._stderr_tail_str()}"
+            )
+        if "exc" in result:
+            raise RuntimeError(
+                f"AlphaGenome worker failed while starting: {result['exc']}\n"
+                f"Stderr tail:\n{self._stderr_tail_str()}"
+            )
+        line = (result.get("line") or "").strip()
+        if line != "READY":
+            rc = self._proc.poll()
+            raise RuntimeError(
+                f"AlphaGenome worker did not signal READY "
+                f"(got {line!r}, returncode={rc}). "
+                f"Stderr tail:\n{self._stderr_tail_str()}"
+            )
+
+    # ------------------------------------------------------------------
+    def predict(self, seq: str, assay_ids: List[str]) -> dict:
+        """Run one forward pass through the worker; returns the same dict shape
+        as :meth:`AlphaGenomeOracle._predict_in_environment` (the spawn path).
+        """
+        import pickle
+        import tempfile
+
+        if self._closed or self._proc is None:
+            raise RuntimeError("AlphaGenome worker is closed.")
+        if self._proc.poll() is not None:
+            raise RuntimeError(
+                f"AlphaGenome worker process has exited "
+                f"(returncode={self._proc.returncode}). "
+                f"Stderr tail:\n{self._stderr_tail_str()}"
+            )
+
+        fd, req_path = tempfile.mkstemp(suffix=".json", prefix="ag_worker_req_")
+        with os.fdopen(fd, "w") as fh:
+            json.dump({"sequence": seq, "assay_ids": assay_ids}, fh)
+
+        result_path = None
+        try:
+            self._proc.stdin.write(req_path + "\n")
+            self._proc.stdin.flush()
+
+            line = self._proc.stdout.readline()
+            if line == "":
+                rc = self._proc.poll()
+                raise RuntimeError(
+                    f"AlphaGenome worker closed its output "
+                    f"(returncode={rc}). Stderr tail:\n{self._stderr_tail_str()}"
+                )
+            line = line.rstrip("\n")
+            if line.startswith("OK "):
+                result_path = line[3:]
+                with open(result_path, "rb") as fh:
+                    return pickle.load(fh)
+            if line.startswith("ERR "):
+                raise RuntimeError(
+                    f"AlphaGenome worker request failed: {line[4:]}"
+                )
+            raise RuntimeError(
+                f"Unexpected control line from AlphaGenome worker: {line!r}. "
+                f"Stderr tail:\n{self._stderr_tail_str()}"
+            )
+        finally:
+            for p in (req_path, result_path):
+                if p and os.path.exists(p):
+                    try:
+                        os.unlink(p)
+                    except OSError:
+                        pass
+
+    # ------------------------------------------------------------------
+    def close(self) -> None:
+        """Stop the worker. Idempotent and best-effort."""
+        if self._closed:
+            return
+        self._closed = True
+        proc = self._proc
+        if proc is not None:
+            try:
+                if proc.poll() is None:
+                    try:
+                        proc.stdin.write("__STOP__\n")
+                        proc.stdin.flush()
+                    except (BrokenPipeError, ValueError, OSError):
+                        pass
+                    try:
+                        proc.wait(timeout=15)
+                    except Exception:
+                        proc.terminate()
+                        try:
+                            proc.wait(timeout=5)
+                        except Exception:
+                            proc.kill()
+            finally:
+                for stream in (proc.stdin, proc.stdout, proc.stderr):
+                    try:
+                        if stream is not None:
+                            stream.close()
+                    except Exception:
+                        pass
+        self._cleanup_init_file()
+
+    def _cleanup_init_file(self) -> None:
+        path = getattr(self, "_init_args_path", None)
+        if path and os.path.exists(path):
+            try:
+                os.unlink(path)
+            except OSError:
+                pass
+
+    def __enter__(self) -> "AlphaGenomePredictWorker":
+        return self
+
+    def __exit__(self, *exc) -> None:
+        self.close()
+
+    def __del__(self):  # pragma: no cover - GC safety net
+        try:
+            self.close()
+        except Exception:
+            pass

--- a/chorus/oracles/alphagenome_source/templates/predict_worker_template.py
+++ b/chorus/oracles/alphagenome_source/templates/predict_worker_template.py
@@ -1,0 +1,213 @@
+"""Persistent AlphaGenome prediction worker.
+
+Executed inside the ``chorus-alphagenome`` conda environment by
+:class:`chorus.oracles.alphagenome.AlphaGenomePredictWorker`. Unlike
+``predict_template.py`` (which loads the model + fetches the ~330 MB GCS
+reference tables on EVERY forward pass), this worker loads the model ONCE
+and then serves an arbitrary number of prediction requests over stdin/stdout.
+
+Protocol (stdout carries ONLY these control lines; everything else — model
+load logs, library chatter — goes to stderr):
+
+  * On startup, after the model has loaded, print exactly ``READY``.
+  * Then loop, reading one path per line from stdin:
+      - ``__STOP__``            -> exit 0.
+      - ``<request_args_path>`` -> a JSON file ``{"sequence", "assay_ids"}``.
+        On success print ``OK <result_pickle_path>``; the result pickle holds
+        the SAME ``{"values": [...], "resolutions": [...]}`` dict that
+        ``predict_template.py`` produces. On a per-request error print
+        ``ERR <single-line-repr>`` and KEEP serving.
+
+The placeholder ``__INIT_ARGS_FILE__`` is replaced at launch with the path to
+a JSON file holding ``{"device", "fold", "length"}`` (same init args the
+per-call template reads from its args file).
+"""
+
+import json
+import os
+import pickle
+import platform as _platform
+import sys
+import tempfile
+import traceback
+
+import numpy as np
+
+
+def _log(*a):
+    """All diagnostic output goes to stderr — stdout is control-only."""
+    print(*a, file=sys.stderr, flush=True)
+
+
+with open("__INIT_ARGS_FILE__") as _inp:
+    _init = json.load(_inp)
+
+# Pre-import device routing: JAX Metal is too experimental for AlphaGenome
+# (missing default_memory_space etc.), so force CPU on macOS unless the user
+# explicitly requests Metal.
+device_str = _init.get("device")
+if _platform.system() == "Darwin" and not (device_str is not None and device_str.startswith("metal")):
+    os.environ["JAX_PLATFORMS"] = "cpu"
+
+import jax
+
+if device_str is not None and device_str.startswith("cpu"):
+    jax_device = jax.devices("cpu")[0]
+elif device_str is not None and device_str.startswith("gpu"):
+    jax_device = jax.devices("gpu")[0]
+elif device_str is not None and device_str.startswith("metal"):
+    jax_device = jax.devices("METAL")[0]
+else:
+    # Auto-detect: prefer CUDA GPU > CPU
+    available_platforms = {d.platform for d in jax.devices()}
+    if "gpu" in available_platforms:
+        jax_device = jax.devices("gpu")[0]
+    else:
+        jax_device = jax.devices("cpu")[0]
+
+# AlphaGenome fetches its GCS reference tables (gencode GTF / splice-site /
+# polyA feathers) fresh on every load via urllib — these are not cached, and
+# the GCS endpoint intermittently fails mid-load, aborting the whole load:
+#   - ssl.SSLEOFError (UNEXPECTED_EOF) at connect time, and
+#   - http.client.IncompleteRead while reading the body of the large
+#     (~330 MB) gencode GTF feather.
+# Retry at both the urlopen (connect) and pd.read_feather (download+parse)
+# levels; the latter is what covers the mid-stream IncompleteRead.
+import http.client as _http
+import ssl as _ssl
+import time as _time
+import urllib.error as _urlerr
+import urllib.request as _urlreq
+import pandas as _pd
+
+_TRANSIENT = (_ssl.SSLError, _urlerr.URLError, OSError,
+              _http.IncompleteRead, _http.HTTPException)
+
+
+def _retry(_fn, *a, **k):
+    last = None
+    for _attempt in range(8):
+        try:
+            return _fn(*a, **k)
+        except _TRANSIENT as exc:
+            last = exc
+            _time.sleep(2 * (_attempt + 1))
+    raise last
+
+
+_orig_urlopen = _urlreq.urlopen
+_urlreq.urlopen = lambda *a, **k: _retry(_orig_urlopen, *a, **k)
+_orig_read_feather = _pd.read_feather
+_pd.read_feather = lambda *a, **k: _retry(_orig_read_feather, *a, **k)
+
+from alphagenome.models.dna_output import OutputType
+from alphagenome_research.model.dna_model import create_from_huggingface
+from chorus.oracles.alphagenome_source.alphagenome_metadata import (
+    get_metadata,
+    SKIPPED_OUTPUT_TYPES,
+)
+
+# Load model ONCE.
+fold = _init.get("fold", "all_folds")
+_log("worker: create_from_huggingface(%r) on %r" % (fold, jax_device))
+model = create_from_huggingface(fold, device=jax_device)
+_log("worker: model loaded")
+
+metadata = get_metadata()
+
+
+def _predict_one(request):
+    """Run one forward pass + per-assay extraction.
+
+    Byte-identical to predict_template.py: same requested_outputs derivation,
+    same _ot_cache, same np.ascontiguousarray(values[:, local_idx], float32).
+    """
+    sequence = request["sequence"]
+    assay_ids = request["assay_ids"]
+
+    # Find which output types are needed
+    needed_output_types = set()
+    for aid in assay_ids:
+        idx = metadata.get_track_by_identifier(aid)
+        if idx is None:
+            raise ValueError(f"Assay ID not found in metadata: {aid}")
+        info = metadata.get_track_info(idx)
+        if info is None:
+            raise ValueError(f"No track info for index {idx} (assay {aid})")
+        needed_output_types.add(info["output_type"])
+
+    # Map output type names to OutputType enum
+    requested_outputs = []
+    for ot in OutputType:
+        if ot.name in needed_output_types and ot.name not in SKIPPED_OUTPUT_TYPES:
+            requested_outputs.append(ot)
+
+    # Run prediction
+    output = model.predict_sequence(
+        sequence,
+        requested_outputs=requested_outputs,
+        ontology_terms=None,
+    )
+
+    # Extract per-assay predictions (cache each OutputType array once;
+    # keep float32 ndarrays for cheap pickling — identical to template).
+    collected = []
+    resolutions = []
+    _ot_cache = {}
+    for aid in assay_ids:
+        idx = metadata.get_track_by_identifier(aid)
+        if idx is None:
+            raise ValueError(f"Assay ID not found in metadata: {aid}")
+        info = metadata.get_track_info(idx)
+        if info is None:
+            raise ValueError(f"No track info for index {idx} (assay {aid})")
+        ot_name = info["output_type"]
+        local_idx = info["local_index"]
+
+        values = _ot_cache.get(ot_name)
+        if values is None:
+            ot_enum = OutputType[ot_name]
+            track_data = output.get(ot_enum)
+            if track_data is None:
+                raise ValueError(
+                    f"No prediction data for output type {ot_name} (assay {aid})"
+                )
+            values = np.asarray(track_data.values)  # (positional_bins, num_tracks)
+            _ot_cache[ot_name] = values
+
+        if local_idx >= values.shape[1]:
+            raise ValueError(
+                f"local_idx {local_idx} out of bounds for output type {ot_name} "
+                f"with {values.shape[1]} tracks (assay {aid})"
+            )
+        track_values = np.ascontiguousarray(values[:, local_idx], dtype=np.float32)
+        collected.append(track_values)
+        resolutions.append(info["resolution"])
+
+    return {"values": collected, "resolutions": resolutions}
+
+
+# Signal readiness AFTER the (slow) model load. The parent blocks on this.
+print("READY", flush=True)
+
+# Serve requests until told to stop (or stdin closes).
+for line in sys.stdin:
+    line = line.strip()
+    if not line:
+        continue
+    if line == "__STOP__":
+        break
+    try:
+        with open(line) as _rf:
+            request = json.load(_rf)
+        result = _predict_one(request)
+        fd, result_path = tempfile.mkstemp(suffix=".pkl", prefix="ag_worker_res_")
+        with os.fdopen(fd, "wb") as _wf:
+            pickle.dump(result, _wf)
+        print("OK " + result_path, flush=True)
+    except Exception as exc:  # one bad request must not kill the worker
+        _log("worker: request failed\n" + traceback.format_exc())
+        rep = repr(exc).replace("\n", " ").replace("\r", " ")
+        print("ERR " + rep, flush=True)
+
+sys.exit(0)

--- a/tests/test_alphagenome_worker.py
+++ b/tests/test_alphagenome_worker.py
@@ -1,0 +1,215 @@
+"""Tests for the persistent AlphaGenome prediction worker.
+
+These are lightweight: the heavy JAX model load is mocked, so they run in
+the base ``chorus`` env without a GPU. They assert the routing + lifecycle
+contract that the real worker upholds:
+
+  * ``_predict_in_environment`` routes through ``self._predict_worker`` when
+    a session is active, and falls back to the per-call spawn otherwise — and
+    both paths return the same dict for the same forward pass.
+  * ``predict_session()`` round-trips, is reentrant (no second worker), and
+    tears the worker down on exit (process gone, ``_predict_worker`` reset).
+  * A non-environment oracle (or any object without ``predict_session``) uses
+    ``contextlib.nullcontext`` in the fine-map hook.
+"""
+from __future__ import annotations
+
+import contextlib
+
+import pytest
+
+from chorus.oracles.alphagenome import AlphaGenomeOracle, AlphaGenomePredictWorker
+
+
+# ---------------------------------------------------------------------------
+# A fake worker so we can exercise routing/lifecycle without a model load.
+# ---------------------------------------------------------------------------
+class _FakeWorker:
+    def __init__(self, oracle):
+        self.oracle = oracle
+        self.closed = False
+        self.calls = []
+
+    def predict(self, seq, assay_ids):
+        self.calls.append((seq, tuple(assay_ids)))
+        # Echo back a deterministic, recognisable result dict in the same
+        # shape the real worker / per-call path returns.
+        return {"values": [f"W:{seq}:{assay_ids}"], "resolutions": [1]}
+
+    def close(self):
+        self.closed = True
+
+
+def _make_oracle(use_environment=True):
+    """Construct an oracle without touching conda or loading anything."""
+    o = AlphaGenomeOracle.__new__(AlphaGenomeOracle)
+    o.oracle_name = "alphagenome"
+    o.use_environment = use_environment
+    o._predict_worker = None
+    o.device = None
+    o.fold = "all_folds"
+    o.sequence_length = 1_048_576
+    o.model_dir = None
+    o.predict_timeout = 600
+    return o
+
+
+# ---------------------------------------------------------------------------
+# Routing: worker vs per-call spawn
+# ---------------------------------------------------------------------------
+def test_predict_in_environment_routes_to_worker_when_active():
+    o = _make_oracle()
+    fake = _FakeWorker(o)
+    o._predict_worker = fake
+    out = o._predict_in_environment("ACGT", ["DNASE:foo"])
+    assert out == {"values": ["W:ACGT:['DNASE:foo']"], "resolutions": [1]}
+    assert fake.calls == [("ACGT", ("DNASE:foo",))]
+
+
+def test_predict_in_environment_uses_spawn_when_no_worker(monkeypatch):
+    o = _make_oracle()
+    captured = {}
+
+    def fake_run_code(code, timeout=None):
+        captured["ran"] = True
+        return {"values": ["spawned"], "resolutions": [1]}
+
+    o.run_code_in_environment = fake_run_code
+    out = o._predict_in_environment("ACGT", ["DNASE:foo"])
+    assert captured.get("ran") is True
+    assert out == {"values": ["spawned"], "resolutions": [1]}
+
+
+def test_worker_and_spawn_agree(monkeypatch):
+    """worker.predict(...) and the per-call spawn path return the SAME dict
+    for the same request (the contract that keeps scores byte-identical)."""
+    o = _make_oracle()
+
+    # Per-call spawn path returns this canned result.
+    canned = {"values": ["shared-result"], "resolutions": [1]}
+    o.run_code_in_environment = lambda code, timeout=None: canned
+    spawn_out = o._predict_in_environment("ACGT", ["DNASE:foo"])
+
+    # Now route through a worker that returns the identical dict.
+    class _Echo(_FakeWorker):
+        def predict(self, seq, assay_ids):
+            return canned
+
+    o._predict_worker = _Echo(o)
+    worker_out = o._predict_in_environment("ACGT", ["DNASE:foo"])
+    assert worker_out == spawn_out
+
+
+# ---------------------------------------------------------------------------
+# predict_session lifecycle
+# ---------------------------------------------------------------------------
+def test_predict_session_spawns_and_closes_worker(monkeypatch):
+    o = _make_oracle()
+    created = []
+
+    def fake_ctor(oracle, *a, **k):
+        w = _FakeWorker(oracle)
+        created.append(w)
+        return w
+
+    monkeypatch.setattr(
+        "chorus.oracles.alphagenome.AlphaGenomePredictWorker", fake_ctor
+    )
+
+    assert o._predict_worker is None
+    with o.predict_session() as ses:
+        assert ses is o
+        assert o._predict_worker is created[0]
+        # Forward passes are served by the worker.
+        out = o._predict_in_environment("ACGT", ["DNASE:foo"])
+        assert out["values"] == ["W:ACGT:['DNASE:foo']"]
+
+    # After the session: worker closed and reference cleared.
+    assert created[0].closed is True
+    assert o._predict_worker is None
+
+
+def test_predict_session_reentrant_no_second_worker(monkeypatch):
+    o = _make_oracle()
+    created = []
+    monkeypatch.setattr(
+        "chorus.oracles.alphagenome.AlphaGenomePredictWorker",
+        lambda oracle, *a, **k: created.append(_FakeWorker(oracle)) or created[-1],
+    )
+
+    with o.predict_session():
+        first = o._predict_worker
+        assert len(created) == 1
+        # Nested session must NOT spawn a second worker, and must NOT tear
+        # the outer one down on exit.
+        with o.predict_session():
+            assert o._predict_worker is first
+            assert len(created) == 1
+        assert o._predict_worker is first
+        assert created[0].closed is False
+    assert created[0].closed is True
+    assert o._predict_worker is None
+
+
+def test_predict_session_noop_when_not_use_environment():
+    o = _make_oracle(use_environment=False)
+    with o.predict_session() as ses:
+        assert ses is o
+        # No worker spawned for the in-process (already fast) path.
+        assert o._predict_worker is None
+    assert o._predict_worker is None
+
+
+def test_predict_session_closes_worker_on_exception(monkeypatch):
+    o = _make_oracle()
+    created = []
+    monkeypatch.setattr(
+        "chorus.oracles.alphagenome.AlphaGenomePredictWorker",
+        lambda oracle, *a, **k: created.append(_FakeWorker(oracle)) or created[-1],
+    )
+    with pytest.raises(ValueError):
+        with o.predict_session():
+            raise ValueError("boom")
+    assert created[0].closed is True
+    assert o._predict_worker is None
+
+
+# ---------------------------------------------------------------------------
+# Fine-map hook: non-AG oracle -> nullcontext
+# ---------------------------------------------------------------------------
+def test_finemap_hook_nullcontext_for_non_ag_oracle():
+    class _PlainOracle:
+        pass
+
+    oracle = _PlainOracle()
+    session = (
+        oracle.predict_session()
+        if hasattr(oracle, "predict_session")
+        else contextlib.nullcontext()
+    )
+    assert isinstance(session, contextlib.nullcontext)
+    with session as val:
+        assert val is None
+
+
+def test_ag_oracle_has_predict_session():
+    assert hasattr(AlphaGenomeOracle, "predict_session")
+    assert hasattr(AlphaGenomeOracle, "get_predict_worker_template")
+
+
+# ---------------------------------------------------------------------------
+# Worker template is valid Python and contains the byte-identical extraction.
+# ---------------------------------------------------------------------------
+def test_worker_template_loads_and_has_extraction():
+    import ast
+
+    o = _make_oracle()
+    o.model_dir = None
+    template, placeholder = o.get_predict_worker_template()
+    assert placeholder == "__INIT_ARGS_FILE__"
+    ast.parse(template)  # must be valid Python
+    # The control protocol + the byte-identical extraction must be present.
+    assert "READY" in template
+    assert "__STOP__" in template
+    assert "np.ascontiguousarray(values[:, local_idx], dtype=np.float32)" in template
+    assert "create_from_huggingface" in template


### PR DESCRIPTION
Makes the **conversational/MCP** fine-map (`fine_map_causal_variant` with `use_environment=True`) ~38× faster — **~3.7 h → 5.8 min** for a 56-variant credible set — **without changing any scores or rankings**.

**Problem.** Each AlphaGenome forward pass on the `use_environment=True` path spawns a fresh `chorus-alphagenome` subprocess that reloads the model *and* re-fetches ~330 MB of GCS reference tables (see `predict_template.py`). The fine-map does 112 of these (56 variants × 2 alleles) → 112 model loads. The in-process path was already fast (model loads once); the MCP path is what readers hit when they run the article's B-1 prompt conversationally.

**Fix — persistent worker (additive, opt-in).**
- New `predict_worker_template.py`: loads the model once, prints `READY`, then serves requests in a loop (`OK <result-file>` / `ERR`); payloads via temp files, stdout control-only, logs to stderr.
- `AlphaGenomePredictWorker` + `oracle.predict_session()` context manager. `_predict_in_environment` routes through an active worker, else the **unchanged** spawn path. `predict_session()` is a no-op when `use_environment=False` or reentrant.
- `prioritize_causal_variants` wraps its scoring loop + top-N rebuild in `predict_session()` (non-AG oracles → `contextlib.nullcontext`). `git diff -w` on causal.py is only the import + the wrap — no ranking-logic change.

**Verification (ml008, GPU).**
- Ranking matches the committed reference exactly: rs9504151 **#1** (composite 1.0), rs62384944 **#4**.
- Model `create_from_huggingface` called **once**; full fine-map 348 s (6.2 s/var) vs ~3.7 h.
- 94 passed / 1 skipped (skip = GPU-bound backend-equivalence test). Single-variant predict, `use_environment=False`, and non-AG oracles unchanged.
- Note: GPU AlphaGenome is inherently nondeterministic (same forward pass twice through the *unchanged* per-call path differs by the same fp magnitude as per-call-vs-worker), so the worker adds zero divergence; the ranking is the authoritative invariant and it holds.