### PR TITLE
docs(readme): fix EPInformer-seq background NPZ size (~770 KB → ~2.3 MB)

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,7 +367,7 @@ The chorus mirrors are byte-identical to the originals (verified via md5 / size 
 | ChromBPNet | ~82 MB | 786 (42 ATAC/DNASE + 744 CHIP) |
 | Sei | ~2.8 MB | 40 classes |
 | LegNet | ~210 KB | 3 cell types |
-| EPInformer-seq | ~770 KB | 33 tracks (11 cell types × 3 assays: DNase, H3K27ac, composite) |
+| EPInformer-seq | ~2.3 MB | 33 tracks (11 cell types × 3 assays: DNase, H3K27ac, composite) |
 
 > **The backgrounds dataset is public — no HuggingFace token required.** `HF_TOKEN` is only needed for the gated AlphaGenome model itself (see [Tokens](#tokens) above). Causal prioritization with auto-LD-fetch needs a separate free LDlink token.
 


### PR DESCRIPTION
The "File size / Tracks covered" backgrounds table already had an EPInformer-seq row, but listed a stale **~770 KB**. The shipped `epinformerseq_pertrack.npz` is **2.32 MB** on disk (33 tracks × effect+activity CDFs).

Correct it to **~2.3 MB** so this table agrees with the per-oracle sample-sizes table (#104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)